### PR TITLE
Add tooltips to graph

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "fuse.js": "^6.5.3",
         "marked": "^4.0.14",
         "swagger-ui": "^4.1.3",
+        "tippy.js": "6.3.7",
         "v-tooltip": "^2.1.3",
         "vee-validate": "^3.4.14",
         "vue": "^2.6.14",
@@ -3366,6 +3367,15 @@
       "peer": true,
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.6",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.6.tgz",
+      "integrity": "sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
       }
     },
     "node_modules/@posva/vuefire-core": {
@@ -17152,6 +17162,14 @@
         "next-tick": "1"
       }
     },
+    "node_modules/tippy.js": {
+      "version": "6.3.7",
+      "resolved": "https://registry.npmjs.org/tippy.js/-/tippy.js-6.3.7.tgz",
+      "integrity": "sha512-E1d3oP2emgJ9dRQZdf3Kkn0qJgI6ZLpyS5z6ZkY1DF3kaQaBsGZsndEpHwx+eC+tYM41HaSNvNtLx8tU57FzTQ==",
+      "dependencies": {
+        "@popperjs/core": "^2.9.0"
+      }
+    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -20999,6 +21017,11 @@
       "integrity": "sha512-UdkG3mLEqXgnlKsWanWcgb6dOjUzJ+XC5f+aWw30qrtjxeNUSfKX1cd5FBzOaXQumoe9nIqeZUvrRJS03HCCtw==",
       "dev": true,
       "peer": true
+    },
+    "@popperjs/core": {
+      "version": "2.11.6",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.6.tgz",
+      "integrity": "sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw=="
     },
     "@posva/vuefire-core": {
       "version": "2.3.4",
@@ -31848,6 +31871,14 @@
       "requires": {
         "es5-ext": "~0.10.46",
         "next-tick": "1"
+      }
+    },
+    "tippy.js": {
+      "version": "6.3.7",
+      "resolved": "https://registry.npmjs.org/tippy.js/-/tippy.js-6.3.7.tgz",
+      "integrity": "sha512-E1d3oP2emgJ9dRQZdf3Kkn0qJgI6ZLpyS5z6ZkY1DF3kaQaBsGZsndEpHwx+eC+tYM41HaSNvNtLx8tU57FzTQ==",
+      "requires": {
+        "@popperjs/core": "^2.9.0"
       }
     },
     "tmpl": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "fuse.js": "^6.5.3",
     "marked": "^4.0.14",
     "swagger-ui": "^4.1.3",
+    "tippy.js": "6.3.7",
     "v-tooltip": "^2.1.3",
     "vee-validate": "^3.4.14",
     "vue": "^2.6.14",

--- a/src/components/IconComment.vue
+++ b/src/components/IconComment.vue
@@ -1,0 +1,50 @@
+<template>
+  <svg :width="width" :height="height" viewBox="0 0 16 15">
+    <path
+      d="M8.53125 4.75C8.53125 5.302 8.97925 5.75 9.53125 5.75C10.0833 5.75 10.5312 5.302 10.5312 4.75C10.5312 4.198 10.0833 3.75 9.53125 3.75C8.97925 3.75 8.53125 4.198 8.53125 4.75Z"
+      :fill="fill"
+    />
+    <path
+      d="M12.2812 5.75C11.7292 5.75 11.2812 5.302 11.2812 4.75C11.2812 4.198 11.7292 3.75 12.2812 3.75C12.8333 3.75 13.2812 4.198 13.2812 4.75C13.2812 5.302 12.8333 5.75 12.2812 5.75Z"
+      :fill="fill"
+    />
+    <path
+      d="M5.71875 4.75C5.71875 5.302 6.16675 5.75 6.71875 5.75C7.27075 5.75 7.71875 5.302 7.71875 4.75C7.71875 4.198 7.27075 3.75 6.71875 3.75C6.16675 3.75 5.71875 4.198 5.71875 4.75Z"
+      :fill="fill"
+    />
+    <path
+      fill-rule="evenodd"
+      clip-rule="evenodd"
+      d="M3 0H16V9.5H11.0195L9.5 11.0196L7.98 9.5H3V0ZM10.6054 8.5H15V1H4V8.5H8.39461L9.5 9.605L10.6054 8.5Z"
+      :fill="fill"
+    />
+    <path
+      d="M2 3V4H1V12.3125H5.39461L6.5 13.4175L7.60539 12.3125H12V10.5H13V13.3125H8.0195L6.5 14.8321L4.98 13.3125H0V3H2Z"
+      :fill="fill"
+    />
+  </svg>
+</template>
+
+<script>
+export default {
+  name: 'IconComment',
+
+  props: {
+    width: {
+      type: Number,
+      required: false,
+      default: 24,
+    },
+    height: {
+      type: Number,
+      required: false,
+      default: 24,
+    },
+    fill: {
+      type: String,
+      required: false,
+      default: 'var(--color-primary)',
+    },
+  },
+};
+</script>

--- a/src/components/IconGraph.vue
+++ b/src/components/IconGraph.vue
@@ -1,0 +1,38 @@
+<template>
+  <svg :width="width" :height="height" viewBox="0 0 15 15">
+    <path
+      d="M14.5 4V0.5H11V1.5H12.7978L8.692 5.605L4.37745 1.23044L1.58645 4.02145L2.29355 4.72855L4.3725 2.6495L8.68755 7.02456L13.5 2.21211V4H14.5Z"
+      :fill="fill"
+    />
+    <path
+      fill-rule="evenodd"
+      clip-rule="evenodd"
+      d="M5.135 6.5H1.55V14.5H0.5V15.5H15.5V14.5H14.445V7H10.86V14.5H9.79V9H6.205V14.5H5.135V6.5ZM11.86 14.5H13.445V8H11.86V14.5ZM8.79 10V14.5H7.205V10H8.79ZM4.135 14.5V7.5H2.55V14.5H4.135Z"
+      :fill="fill"
+    />
+  </svg>
+</template>
+
+<script>
+export default {
+  name: 'IconGraph',
+
+  props: {
+    width: {
+      type: Number,
+      required: false,
+      default: 24,
+    },
+    height: {
+      type: Number,
+      required: false,
+      default: 24,
+    },
+    fill: {
+      type: String,
+      required: false,
+      default: 'var(--color-primary)',
+    },
+  },
+};
+</script>

--- a/src/components/IndicatorTooltip.vue
+++ b/src/components/IndicatorTooltip.vue
@@ -1,0 +1,65 @@
+<template>
+  <div class="tooltip">
+    <div>
+      <icon-calendar :height="15" :width="15"/>
+      {{ formattedTimestamp }}
+    </div>
+    <div>
+      <icon-graph :height="15" :width="15"/>
+      {{ value }}
+    </div>
+    <div v-if="comment">
+      <icon-comment :height="15" :width="15"/>
+      {{ comment }}
+    </div>
+  </div>
+</template>
+
+<script>
+import { dateShort } from '@/util';
+import IconCalendar from './IconCalendar.vue';
+import IconComment from './IconComment.vue';
+import IconGraph from './IconGraph.vue';
+
+export default {
+  name: 'IndicatorTooltip',
+  components: {
+    IconCalendar,
+    IconComment,
+    IconGraph
+  },
+  props: {
+    timestamp: {
+      type: Date,
+      required: true,
+    },
+    value: {
+      type: Number,
+      required: true,
+    },
+    comment: {
+      type: String,
+      required: false,
+    },
+  },
+  computed: {
+    formattedTimestamp() {
+      return dateShort(this.timestamp);
+    }
+  }
+};
+</script>
+
+<style lang="scss" scoped>
+.tooltip > div {
+  display: flex;
+  font-size: 0.75rem;
+  margin: 0.5rem 0;
+  max-width: 200px;
+
+  > svg {
+    flex-shrink: 0;
+    margin-right: 0.5rem;
+  }
+}
+</style>

--- a/src/styles/_tooltip.scss
+++ b/src/styles/_tooltip.scss
@@ -102,3 +102,22 @@
     font-size: 1rem !important;
   }
 }
+
+/* Tippy */
+.tippy-box[data-theme~='ok'] {
+  background-color: var(--color-bg);
+  color: var(--color-primary);
+  border-radius: 0;
+}
+.tippy-box[data-theme~='ok'][data-placement^='top'] > .tippy-arrow::before {
+  border-top-color: var(--color-bg);
+}
+.tippy-box[data-theme~='ok'][data-placement^='bottom'] > .tippy-arrow::before {
+  border-bottom-color: var(--color-bg);
+}
+.tippy-box[data-theme~='ok'][data-placement^='left'] > .tippy-arrow::before {
+  border-left-color: var(--color-bg);
+}
+.tippy-box[data-theme~='ok'][data-placement^='right'] > .tippy-arrow::before {
+  border-right-color: var(--color-bg);
+}

--- a/src/util/LineChart/linechart-helpers.js
+++ b/src/util/LineChart/linechart-helpers.js
@@ -1,3 +1,5 @@
+import { addCommentSymbol } from './symbols';
+
 const padding = { left: 60, top: 20, right: 10, bottom: 20 };
 
 export const GRAPH_COLORS = {
@@ -29,8 +31,9 @@ export function initSvg(svg) {
     .attr('stroke', 'black')
     .attr('stroke-opacity', 0.2);
 
-  this.gradient = this.svg
-    .append('defs')
+  this.defs = this.svg.append('defs')
+  this.gradient = this.defs
+
     .append('linearGradient')
     .attr('id', 'areaGradient')
     .attr('x1', '0%')
@@ -46,6 +49,13 @@ export function initSvg(svg) {
     .append('stop')
     .attr('id', 'stop')
     .call(styleGradientStop.bind(this));
+
+  this.valueIndicators = this.canvas
+    .append('g')
+    .classed('indicators', true);
+
+  this.defs
+    .call(addCommentSymbol);
 }
 
 export function styleGradientStart(el) {
@@ -67,6 +77,13 @@ export function styleValueLine(el) {
     .attr('fill', 'none')
     .attr('stroke', GRAPH_COLORS.line)
     .attr('stroke-width', 3);
+}
+
+export function styleValueIndicators(el) {
+  el.classed('indicator', true)
+    .style('fill', (d) => {
+      return (d?.comment ? 'url(#comment-symbol)' : 'transparent')
+    })
 }
 
 function styleArea(el) {

--- a/src/util/LineChart/symbols.js
+++ b/src/util/LineChart/symbols.js
@@ -1,0 +1,40 @@
+export function addCommentSymbol(el) {
+  const fill = 'var(--color-secondary-light)';
+  const color = 'var(--primary-color)';
+
+  const pattern = el.append('pattern')
+    .attr("id", "comment-symbol")
+    .attr("patternUnits", "userSpaceOnUse")
+    .attr("width", "16")
+    .attr("height", "16")
+    .attr("x", "11")
+    .attr("y", "12")
+    .attr("viewBox", "0 0 25 25");
+
+  pattern.append("rect")
+    .attr("width", "100%")
+    .attr("height", "100%")
+    .attr("fill", fill);
+
+  pattern.append("path")
+    .attr("d", "M8.53125 4.75C8.53125 5.302 8.97925 5.75 9.53125 5.75C10.0833 5.75 10.5312 5.302 10.5312 4.75C10.5312 4.198 10.0833 3.75 9.53125 3.75C8.97925 3.75 8.53125 4.198 8.53125 4.75Z")
+    .attr("fill", color);
+
+  pattern.append("path")
+    .attr("d", "M12.2812 5.75C11.7292 5.75 11.2812 5.302 11.2812 4.75C11.2812 4.198 11.7292 3.75 12.2812 3.75C12.8333 3.75 13.2812 4.198 13.2812 4.75C13.2812 5.302 12.8333 5.75 12.2812 5.75Z")
+    .attr("fill", color);
+
+  pattern.append("path")
+    .attr("d", "M5.71875 4.75C5.71875 5.302 6.16675 5.75 6.71875 5.75C7.27075 5.75 7.71875 5.302 7.71875 4.75C7.71875 4.198 7.27075 3.75 6.71875 3.75C6.16675 3.75 5.71875 4.198 5.71875 4.75Z")
+    .attr("fill", color);
+
+  pattern.append("path")
+    .attr("fill-rule", "evenodd")
+    .attr("clip-rule", "evenodd")
+    .attr("d", "M3 0H16V9.5H11.0195L9.5 11.0196L7.98 9.5H3V0ZM10.6054 8.5H15V1H4V8.5H8.39461L9.5 9.605L10.6054 8.5Z")
+    .attr("fill", color);
+
+  pattern.append("path")
+    .attr("d", "M2 3V4H1V12.3125H5.39461L6.5 13.4175L7.60539 12.3125H12V10.5H13V13.3125H8.0195L6.5 14.8321L4.98 13.3125H0V3H2Z")
+    .attr("fill", color);
+}


### PR DESCRIPTION
Adds tooltips triggered by either hover or click on data points in graph. Allows for optional drawing of comment symbol for values that may be accompanied by a comment (in the future). Likely cleaner ways to do this with D3!? 😅 

TODO: 
* Format value in tooltip depending on type.
* Decide where comments should "live".

<img src="https://user-images.githubusercontent.com/2866225/185079511-95f3b8e7-f060-4bd8-ba74-95bec4c981c5.png" width="300"/>
