### PR TITLE
Fix ESLint `operator-assignment` rule config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,7 +15,7 @@ module.exports = {
     'func-names': 'off',
     'no-restricted-syntax': 'off',
     'import/extensions': [0, 'never'],
-    'operator-assignment': 'never',
+    'operator-assignment': ['error', 'never'],
   },
   parserOptions: {
     parser: '@babel/eslint-parser',


### PR DESCRIPTION
The previous config resulted in the following error message:

  Configuration for rule "operator-assignment" is invalid:
  Severity should be one of the following: 0 = off, 1 = warn, 2 = error (you passed '"never"').

Specify the severity to stop it from complaining.