### PR TITLE
Make "so far this year" end at the current date

### DIFF
--- a/src/components/DashboardResultIndicatorsSection.vue
+++ b/src/components/DashboardResultIndicatorsSection.vue
@@ -68,7 +68,6 @@ import { mapState } from 'vuex';
 import { extent } from 'd3-array';
 import firebase from 'firebase/app';
 import { db } from '@/config/firebaseConfig';
-import endOfDay from 'date-fns/endOfDay';
 import { saveSvgAsPng } from 'save-svg-as-png';
 import LineChart from '@/util/LineChart';
 import { numberLocale } from '@/util';
@@ -103,7 +102,7 @@ const getResultIndicatorPeriods = () => {
       label: 'Hittil i år',
       key: 'year',
       startDate: new Date(currentYear, 0, 1),
-      endDate: endOfDay(new Date(currentYear, 11, 31)),
+      endDate: currentDate,
     },
   };
 };


### PR DESCRIPTION
"So far this year" extended until the end of the current year, leaving much of the graph blank (especially early in the year). Make it end at the current date instead, giving more screen estate to real data.