### PR TITLE
Support choosing KPI type

### DIFF
--- a/src/components/modals/AddKPIModal.vue
+++ b/src/components/modals/AddKPIModal.vue
@@ -44,6 +44,32 @@
           </label>
         </validation-provider>
 
+        <hr class="ods-hr" />
+
+        <validation-provider v-slot="{ errors }" rules="required" name="kpiType">
+          <div class="form-group">
+            <span class="form-label form-help--hasPrimaryBackground">
+              {{ $t('fields.kpitype') }}
+            </span>
+            <span v-if="errors[0]" class="form-field--error">
+              {{ errors[0] }}
+            </span>
+            <div v-for="{ id, label, description } in types" :key="id"
+                 class="ods-form-group descriptive-radio">
+              <input type="radio" :id="id + _uid" class="ods-form-radio"
+                     name="radio-group" v-model="kpi.kpiType" :value="id" />
+              <label class="ods-form-label form-help--hasPrimaryBackground" :for="id + _uid">
+                <span class="title">{{ label }}</span>
+              </label>
+              <label class="description form-help--hasPrimaryBackground" :for="id + _uid">
+                {{ description }}
+              </label>
+            </div>
+          </div>
+        </validation-provider>
+
+        <hr class="ods-hr" />
+
         <div class="toggle__container">
           <span class="toggle__label">
             {{ $t('kpi.api.radio') }}
@@ -140,7 +166,7 @@
 
 <script>
 import { mapState } from 'vuex';
-import { kpiFormats } from '@/util/kpiHelpers';
+import { kpiFormats, kpiTypes } from '@/util/kpiHelpers';
 import Kpi from '@/db/Kpi';
 import ModalWrapper from './ModalWrapper.vue';
 
@@ -155,6 +181,7 @@ export default {
     value: 0,
     loading: false,
     formats: kpiFormats(),
+    types: kpiTypes(),
     kpi: {
       name: '',
       description: '',

--- a/src/components/modals/AddKPIModal.vue
+++ b/src/components/modals/AddKPIModal.vue
@@ -56,12 +56,12 @@
             </span>
             <div v-for="{ id, label, description } in types" :key="id"
                  class="ods-form-group descriptive-radio">
-              <input type="radio" :id="id + _uid" class="ods-form-radio"
+              <input type="radio" :id="'kpi-type-' + id" class="ods-form-radio"
                      name="radio-group" v-model="kpi.kpiType" :value="id" />
-              <label class="ods-form-label form-help--hasPrimaryBackground" :for="id + _uid">
+              <label class="ods-form-label form-help--hasPrimaryBackground" :for="'kpi-type-' + id">
                 <span class="title">{{ label }}</span>
               </label>
-              <label class="description form-help--hasPrimaryBackground" :for="id + _uid">
+              <label class="description form-help--hasPrimaryBackground" :for="'kpi-type-' + id">
                 {{ description }}
               </label>
             </div>

--- a/src/components/modals/AddKPIModal.vue
+++ b/src/components/modals/AddKPIModal.vue
@@ -20,11 +20,7 @@
           <span class="form-label form-label--hasPrimaryBackground">
             {{ $t('kpi.description') }}
           </span>
-          <textarea
-            v-model="kpi.description"
-            class="form__field"
-            rows="4"
-          />
+          <textarea v-model="kpi.description" class="form__field" rows="4" />
         </label>
 
         <validation-provider v-slot="{ errors }" rules="required" name="format">
@@ -33,8 +29,7 @@
               {{ $t('kpi.display') }}
             </span>
             <select v-model="kpi.format" class="form__field">
-              <option
-                v-for="{ id, label } in formats" :key="id" :value="id">
+              <option v-for="{ id, label } in formats" :key="id" :value="id">
                 {{ label }}
               </option>
             </select>
@@ -46,7 +41,11 @@
 
         <hr class="ods-hr" />
 
-        <validation-provider v-slot="{ errors }" rules="required" name="kpiType">
+        <validation-provider
+          v-slot="{ errors }"
+          rules="required"
+          name="kpiType"
+        >
           <div class="form-group">
             <span class="form-label form-help--hasPrimaryBackground">
               {{ $t('fields.kpitype') }}
@@ -54,14 +53,29 @@
             <span v-if="errors[0]" class="form-field--error">
               {{ errors[0] }}
             </span>
-            <div v-for="{ id, label, description } in types" :key="id"
-                 class="ods-form-group descriptive-radio">
-              <input type="radio" :id="'kpi-type-' + id" class="ods-form-radio"
-                     name="radio-group" v-model="kpi.kpiType" :value="id" />
-              <label class="ods-form-label form-help--hasPrimaryBackground" :for="'kpi-type-' + id">
+            <div
+              v-for="{ id, label, description } in types"
+              :key="id"
+              class="ods-form-group descriptive-radio"
+            >
+              <input
+                :id="'kpi-type-' + id"
+                v-model="kpi.kpiType"
+                :value="id"
+                type="radio"
+                class="ods-form-radio"
+                name="radio-group"
+              />
+              <label
+                class="ods-form-label form-help--hasPrimaryBackground"
+                :for="'kpi-type-' + id"
+              >
                 <span class="title">{{ label }}</span>
               </label>
-              <label class="description form-help--hasPrimaryBackground" :for="'kpi-type-' + id">
+              <label
+                class="description form-help--hasPrimaryBackground"
+                :for="'kpi-type-' + id"
+              >
                 {{ description }}
               </label>
             </div>
@@ -79,11 +93,7 @@
             />
           </span>
           <label class="toggle">
-            <input
-              v-model="kpi.api"
-              class="toggle__input"
-              type="checkbox"
-            />
+            <input v-model="kpi.api" class="toggle__input" type="checkbox" />
             <span class="toggle__switch"></span>
           </label>
         </div>

--- a/src/components/modals/AddKPIModal.vue
+++ b/src/components/modals/AddKPIModal.vue
@@ -186,6 +186,7 @@ export default {
       name: '',
       description: '',
       format: null,
+      kpiType: null,
       sheetId: '',
       sheetName: 'Sheet1',
       sheetCell: 'A1',

--- a/src/locale/locales/en-US.json
+++ b/src/locale/locales/en-US.json
@@ -22,6 +22,20 @@
       "integer": "Integer",
       "percentage": "Percentage"
     },
+    "types": {
+      "plain": {
+        "label": "KPI",
+        "description": "KPIs are measurements that the team or department whishes to keep an eye on. KPIs are displayed on the top of the team or department page they belong to."
+      },
+      "keyFigure": {
+        "label": "KPI with reporting",
+        "description": "Is the KPI so important that it should be shown on the department's dashboard for reporting?"
+      },
+      "resultIndicator": {
+        "label": "Result indicator",
+        "description": "Is the KPI so important that it is defined as a result indicator for the department and has a target figure? The result indicator is also shown on the dashboard."
+      }
+    },
     "heading": "KPIs",
     "sheetsDetails": "Sheets details",
     "itemRowError": "error",
@@ -46,7 +60,7 @@
     "description": "Description",
     "slug": "Slug",
     "department": "Department",
-    "kpitype": "KPI type",
+    "kpitype": "Type",
     "unit": "Unit of measurement",
     "startValue": "Start value",
     "targetValue": "Target value",
@@ -120,7 +134,6 @@
     "keyResult": "Key result",
     "period": "Period",
     "back": "back",
-
     "frontPage": "Front page",
     "signIn": "Please sign in",
     "orgs": "Organizations",

--- a/src/locale/locales/nb-NO.json
+++ b/src/locale/locales/nb-NO.json
@@ -22,6 +22,20 @@
       "integer": "Heltall",
       "percentage": "Prosent"
     },
+    "types": {
+      "plain": {
+        "label": "KPI",
+        "description": "KPI-er er måletall som teamet eller produktområdet ønsker å følge med på. KPI-er vises øverst på team- eller produktområdesiden de hører til."
+      },
+      "keyFigure": {
+        "label": "KPI med rapportering",
+        "description": "Er KPI-en er så viktig at den skal vises på dashbordet til produktområdet for rapportering?"
+      },
+      "resultIndicator": {
+        "label": "Resultatindikator",
+        "description": "Er KPI-en så viktig at den er definert som produktområdets resultatindikator og har et måltall? Resultatindikatoren vises også i dashbordet."
+      }
+    },
     "heading": "KPI-er",
     "sheetsDetails": "Sheets-detaljer",
     "itemRowError": "feil",
@@ -46,7 +60,7 @@
     "description": "Beskrivelse",
     "slug": "Slug",
     "department": "Produktområde",
-    "kpitype": "KPI-type",
+    "kpitype": "Type",
     "unit": "Måleenhet",
     "startValue": "Startverdi",
     "targetValue": "Målverdi",

--- a/src/styles/_forms.scss
+++ b/src/styles/_forms.scss
@@ -189,3 +189,17 @@ textarea {
   margin-bottom: 1rem;
   color: var(--color-text);
 }
+
+.descriptive-radio {
+  margin: 1.5rem 0;
+
+  .title {
+    margin-left: 0.25rem;
+    font-weight: 500;
+  }
+
+  .description {
+    display: block;
+    margin-top: 0.25rem;
+  }
+}

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -14,6 +14,7 @@
 @use 'alerts';
 @use 'vSelect';
 @use 'ods/ods-forms';
+@use 'ods/ods-hr';
 
 @function hexToRGB($hex) {
   @return red($hex), green($hex), blue($hex);

--- a/src/styles/ods/ods-hr.scss
+++ b/src/styles/ods/ods-hr.scss
@@ -1,0 +1,8 @@
+/*
+ * Horisontal divider <hr>
+ */
+
+.ods-hr {
+  border: 0;
+  border-top: 1px solid #cccccc;
+}

--- a/src/util/kpiHelpers.js
+++ b/src/util/kpiHelpers.js
@@ -18,6 +18,29 @@ export function kpiFormats () {
 };
 
 /**
+ * Return a list of available KPI types.
+ */
+export function kpiTypes () {
+  return [
+    {
+      id: 'plain',
+      label: i18n.t('kpi.types.plain.label'),
+      description: i18n.t('kpi.types.plain.description'),
+    },
+    {
+      id: 'keyfig',
+      label: i18n.t('kpi.types.keyFigure.label'),
+      description: i18n.t('kpi.types.keyFigure.description'),
+    },
+    {
+      id: 'ri',
+      label: i18n.t('kpi.types.resultIndicator.label'),
+      description: i18n.t('kpi.types.resultIndicator.description'),
+    },
+  ];
+};
+
+/**
  * Return a value formatter function.
  *
  * `defaultSpecifier` is the format specifier to use in normal cases, while

--- a/src/views/ItemAdmin/ItemAdminKPI.vue
+++ b/src/views/ItemAdmin/ItemAdminKPI.vue
@@ -45,6 +45,30 @@
           </label>
         </validation-provider>
 
+        <hr class="ods-hr" />
+
+        <validation-provider v-slot="{ errors }" rules="required" name="kpiType">
+          <div class="form-group">
+            <span class="form-label">{{ $t('fields.kpitype') }}</span>
+            <span v-if="errors[0]" class="form-field--error">
+              {{ errors[0] }}
+            </span>
+            <div v-for="{ id, label, description } in types" :key="id"
+                 class="ods-form-group descriptive-radio">
+              <input type="radio" :id="id + _uid" class="ods-form-radio"
+                     name="radio-group" v-model="localKpi.kpiType" :value="id" />
+              <label class="ods-form-label" :for="id + _uid">
+                <span class="title">{{ label }}</span>
+              </label>
+              <label class="description" :for="id + _uid">
+                {{ description }}
+              </label>
+            </div>
+          </div>
+        </validation-provider>
+
+        <hr class="ods-hr" />
+
         <div class="toggle__container">
           <span class="toggle__label">
             {{ $t('kpi.api.radio') }}
@@ -130,7 +154,7 @@
 <script>
 import { mapState } from 'vuex';
 import IconArrowCircle from '@/assets/IconArrowCircle.vue';
-import { kpiFormats } from '@/util/kpiHelpers';
+import { kpiFormats, kpiTypes } from '@/util/kpiHelpers';
 import Kpi from '@/db/Kpi';
 
 export default {
@@ -151,6 +175,7 @@ export default {
     showAddKPIModal: false,
     localKpi: null,
     formats: kpiFormats(),
+    types: kpiTypes(),
   }),
 
   computed: {
@@ -162,6 +187,9 @@ export default {
       immediate: true,
       handler() {
         this.localKpi = this.kpi;
+        if (!this.localKpi.kpiType) {
+          this.localKpi.kpiType = 'plain';
+        }
       },
     },
   },

--- a/src/views/ItemAdmin/ItemAdminKPI.vue
+++ b/src/views/ItemAdmin/ItemAdminKPI.vue
@@ -187,9 +187,6 @@ export default {
       immediate: true,
       handler() {
         this.localKpi = this.kpi;
-        if (!this.localKpi.kpiType) {
-          this.localKpi.kpiType = 'plain';
-        }
       },
     },
   },

--- a/src/views/ItemAdmin/ItemAdminKPI.vue
+++ b/src/views/ItemAdmin/ItemAdminKPI.vue
@@ -55,12 +55,12 @@
             </span>
             <div v-for="{ id, label, description } in types" :key="id"
                  class="ods-form-group descriptive-radio">
-              <input type="radio" :id="id + _uid" class="ods-form-radio"
+              <input type="radio" :id="localKpi.id + '-' + id" class="ods-form-radio"
                      name="radio-group" v-model="localKpi.kpiType" :value="id" />
-              <label class="ods-form-label" :for="id + _uid">
+              <label class="ods-form-label" :for="localKpi.id + '-' + id">
                 <span class="title">{{ label }}</span>
               </label>
-              <label class="description" :for="id + _uid">
+              <label class="description" :for="localKpi.id + '-' + id">
                 {{ description }}
               </label>
             </div>


### PR DESCRIPTION
Add a new KPI type choice in the KPI add and edit forms.

The background on the KPI add modal is not optimal right now together with ODS components, but that will be fixed separately.