### PR TITLE
Allow only daily KPI measurement values: API and frontend updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ Firebase now exports storage emulator as well, even if you don't use it. These n
 
 It is possible to set up open API end points for users outside of the OKR-tracker frontend to update progress of Key Results and KPI's. To do so, you only need to deploy all the functions as usual, and then give the users the Cloud Function URL, but we do not recommend to call the Cloud Function directly. The better approach would be to set up a Google Cloud API Gateway and then reroute all the calls to the right Cloud Function.
 
-We have set up an Open API specification which you can check out [here](./public/openapi/v1.1.1.yaml).
+We have set up an Open API specification which you can check out [here](./public/openapi/v1.2.0.yaml).
 
 You can read more about on how to set up an API Gateway [here](https://cloud.google.com/api-gateway/docs/quickstart).
 

--- a/functions/api/helpers.js
+++ b/functions/api/helpers.js
@@ -1,4 +1,5 @@
 import { FieldValue } from 'firebase-admin/firestore';
+import { endOfDay, startOfDay, setHours } from 'date-fns';
 
 /**
  * Return a user's display name. If the referenced Firestore reference
@@ -17,6 +18,43 @@ export async function getUserDisplayName(userRef) {
     });
   }
   return userRef.split('users/')[1];
+}
+
+/** Update the KPI progression collection with at most one value each
+ * day. Check for any existing values on specified `date` and either
+ * add new or update existing measurement value.
+ *
+ * `kpiRef` is the reference to the parent KPI to update.
+ * `date` specifies which date the measurement is made.
+ * `value` is the progression value to set.
+ */
+export async function updateKPIProgressionValue(kpiRef, date, value) {
+  date = startOfDay(date);
+
+  const progressCollectionRef = kpiRef.collection('progress');
+
+  const existingValueRef = await progressCollectionRef
+    .orderBy('timestamp', 'desc')
+    .where('timestamp', '>=', date)
+    .where('timestamp', '<=', endOfDay(date))
+    .limit(1)
+    .get()
+    .then((snapshot) => (!snapshot.empty ? snapshot.docs[0].ref : null));
+
+  if (existingValueRef) {
+    await existingValueRef.update({
+      value,
+      edited: new Date(),
+    });
+  } else {
+    await progressCollectionRef.add({
+      value,
+      timestamp: setHours(date, 12),
+      created: new Date(),
+    });
+  }
+
+  await refreshKPILatestValue(kpiRef);
 }
 
 /** Fetch latest progression measurement and update the KPI object
@@ -42,7 +80,7 @@ export async function refreshKPILatestValue(kpiRef) {
     await kpiRef.update({
       error: FieldValue.delete(),
       currentValue: FieldValue.delete(),
-      valid: FieldValue.delete(),
+      valid: true,
     });
   }
 }

--- a/functions/api/helpers.js
+++ b/functions/api/helpers.js
@@ -1,5 +1,4 @@
-import { getFirestore } from 'firebase-admin/firestore';
-import validator from 'express-validator';
+import { FieldValue } from 'firebase-admin/firestore';
 
 /**
  * Return a user's display name. If the referenced Firestore reference
@@ -7,7 +6,7 @@ import validator from 'express-validator';
  *
  * `userRef` is the Firestore reference to resolve.
  */
-async function getUserDisplayName(userRef) {
+export async function getUserDisplayName(userRef) {
   if (typeof userRef.get === 'function') {
     return userRef.get().then((snapshot) => {
       if (!snapshot.exists) {
@@ -20,4 +19,30 @@ async function getUserDisplayName(userRef) {
   return userRef.split('users/')[1];
 }
 
-export default getUserDisplayName;
+/** Fetch latest progression measurement and update the KPI object
+ * accordingly. If no value is found, delete relevant fields.
+ *
+ * `kpiRef` is the Firestore reference to update.
+ */
+export async function refreshKPILatestValue(kpiRef) {
+  const latestValueData = await kpiRef
+    .collection('progress')
+    .orderBy('timestamp', 'desc')
+    .limit(1)
+    .get()
+    .then((snapshot) => (!snapshot.empty ? snapshot.docs[0].data() : null));
+
+  if (latestValueData) {
+    await kpiRef.update({
+      error: FieldValue.delete(),
+      currentValue: latestValueData.value,
+      valid: true,
+    });
+  } else {
+    await kpiRef.update({
+      error: FieldValue.delete(),
+      currentValue: FieldValue.delete(),
+      valid: FieldValue.delete(),
+    });
+  }
+}

--- a/functions/api/helpers.js
+++ b/functions/api/helpers.js
@@ -45,6 +45,7 @@ export async function updateKPIProgressionValue(kpiRef, date, value) {
     await existingValueRef.update({
       value,
       edited: new Date(),
+      editedBy: null,
     });
   } else {
     await progressCollectionRef.add({

--- a/functions/api/routes/kpi.js
+++ b/functions/api/routes/kpi.js
@@ -1,16 +1,20 @@
 import express from 'express';
 import { getFirestore, FieldValue } from 'firebase-admin/firestore';
 import validator from 'express-validator';
-import getUserDisplayName from '../helpers.js';
+import { format, endOfDay, setHours } from 'date-fns';
+import { getUserDisplayName, refreshKPILatestValue } from '../helpers.js';
+import {
+  dateValidator,
+  idValidator,
+  progressValidator,
+  teamSecretValidator,
+  valueValidator,
+} from '../validators.js';
 
-const { body, param, matchedData } = validator;
+const { matchedData, validationResult } = validator;
 const router = express.Router();
-const validate = [
-  body('progress').isFloat().escape(),
-  param('id').trim().escape(),
-];
 
-router.post('/:id', ...validate, async (req, res) => {
+router.post('/:id', idValidator, progressValidator, async (req, res) => {
   const sanitized = matchedData(req);
   const { progress, id } = sanitized;
   const teamSecret = req.header('okr-team-secret');
@@ -75,7 +79,7 @@ router.post('/:id', ...validate, async (req, res) => {
   }
 });
 
-router.get('/:id', param('id').trim().escape(), async (req, res) => {
+router.get('/:id', idValidator, async (req, res) => {
   const sanitized = matchedData(req);
   const { id } = sanitized;
 
@@ -132,7 +136,7 @@ router.get('/:id', param('id').trim().escape(), async (req, res) => {
   }
 });
 
-router.get('/:id/values', param('id').trim().escape(), async (req, res) => {
+router.get('/:id/values', idValidator, async (req, res) => {
   const { id } = matchedData(req);
 
   const db = getFirestore();
@@ -193,5 +197,183 @@ router.get('/:id/values', param('id').trim().escape(), async (req, res) => {
     res.status(500).send(`Cannot get KPI by ID: (${id}}`);
   }
 });
+
+router.put(
+  '/:id/values/:date',
+  teamSecretValidator,
+  idValidator,
+  dateValidator,
+  valueValidator,
+  async (req, res) => {
+    const result = validationResult(req);
+
+    if (!result.isEmpty()) {
+      res.status(400).json({
+        message: 'Invalid request data',
+        errors: result.mapped(),
+      });
+      return;
+    }
+
+    const { 'okr-team-secret': teamSecret, id, date, value } = matchedData(req);
+
+    const db = getFirestore();
+
+    try {
+      const kpi = await db.collection('kpis').doc(id).get();
+
+      const { exists, ref } = kpi;
+
+      if (!exists) {
+        res.status(404).json({ message: `Could not find KPI with ID: ${id}` });
+        return;
+      }
+
+      const { parent } = kpi.data();
+      const parentData = await parent.get().then((snapshot) => snapshot.data());
+
+      if (!parentData.secret) {
+        res.status(401).json({
+          message:
+            `'${parentData.name}' is not set up for API usage. Please set ` +
+            'a secret using the OKR Tracker admin interface.',
+        });
+        return;
+      }
+      if (parentData.secret !== teamSecret) {
+        res.status(401).json({ message: 'Wrong okr-team-secret' });
+        return;
+      }
+
+      const progressCollectionRef = ref.collection('progress');
+
+      // Check for any existing values on specified date, and if so, return
+      // the most recent measurement value for backwards compatibility.
+      const existingValueRef = await progressCollectionRef
+        .orderBy('timestamp', 'desc')
+        .where('timestamp', '>=', date)
+        .where('timestamp', '<=', endOfDay(date))
+        .limit(1)
+        .get()
+        .then((snapshot) => (!snapshot.empty ? snapshot.docs[0].ref : null));
+
+      if (existingValueRef) {
+        await existingValueRef.update({
+          value,
+          edited: new Date(),
+        });
+      } else {
+        await progressCollectionRef.add({
+          value,
+          timestamp: setHours(date, 12),
+          created: new Date(),
+        });
+      }
+
+      await refreshKPILatestValue(ref);
+
+      res.json({
+        message: `KPI progression value for ${format(
+          date,
+          'yyyy-MM-dd'
+        )} updated to ${value}`,
+      });
+    } catch (e) {
+      console.error('ERROR: ', e.message);
+      res
+        .status(500)
+        .json({ message: 'Could not update KPI progression value' });
+    }
+  }
+);
+
+router.delete(
+  '/:id/values/:date',
+  teamSecretValidator,
+  idValidator,
+  dateValidator,
+  async (req, res) => {
+    const result = validationResult(req);
+
+    if (!result.isEmpty()) {
+      res.status(400).json({
+        message: 'Invalid request data',
+        errors: result.mapped(),
+      });
+      return;
+    }
+
+    const { 'okr-team-secret': teamSecret, id, date } = matchedData(req);
+
+    const db = getFirestore();
+
+    try {
+      const kpi = await db.collection('kpis').doc(id).get();
+
+      const { exists, ref } = kpi;
+
+      if (!exists) {
+        res.status(404).json({ message: `Could not find KPI with ID: ${id}` });
+        return;
+      }
+
+      const { parent } = kpi.data();
+      const parentData = await parent.get().then((snapshot) => snapshot.data());
+
+      if (!parentData.secret) {
+        res.status(401).json({
+          message:
+            `'${parentData.name}' is not set up for API usage. Please set ` +
+            'a secret using the OKR Tracker admin interface.',
+        });
+        return;
+      }
+      if (parentData.secret !== teamSecret) {
+        res.status(401).json({ message: 'Wrong okr-team-secret' });
+        return;
+      }
+
+      // Batch delete all values registered on specified date.
+      const valuesSnapshot = await ref
+        .collection('progress')
+        .orderBy('timestamp', 'desc')
+        .where('timestamp', '>=', date)
+        .where('timestamp', '<=', endOfDay(date))
+        .get();
+
+      if (valuesSnapshot.empty) {
+        res.status(404).json({
+          message: `No KPI progression value found for ${format(
+            date,
+            'yyyy-MM-dd'
+          )}`,
+        });
+        return;
+      }
+
+      const batch = db.batch();
+
+      valuesSnapshot.forEach((doc) => {
+        batch.delete(doc.ref);
+      });
+
+      await batch.commit().then(() => {
+        res.json({
+          message: `KPI progression value for ${format(
+            date,
+            'yyyy-MM-dd'
+          )} deleted`,
+        });
+      });
+
+      await refreshKPILatestValue(ref);
+    } catch (e) {
+      console.error('ERROR: ', e.message);
+      res
+        .status(500)
+        .json({ message: 'Could not delete KPI progression value' });
+    }
+  }
+);
 
 export default router;

--- a/functions/api/validators.js
+++ b/functions/api/validators.js
@@ -1,0 +1,34 @@
+import validator from 'express-validator';
+
+const { body, header, param } = validator;
+
+export const teamSecretValidator = header('okr-team-secret')
+  .not()
+  .isEmpty()
+  .withMessage('The `okr-team-secret` header is required');
+
+export const idValidator = param('id').trim().escape();
+
+export const dateValidator = param('date')
+  .trim()
+  .isDate()
+  .escape()
+  .toDate()
+  .custom((date) => {
+    if (date.getTime() > new Date().getTime()) {
+      throw new Error('Future dates not allowed');
+    }
+    return true;
+  });
+
+const checkMeasurementValue = (field) =>
+  field
+    .not()
+    .isEmpty()
+    .withMessage('Required field')
+    .isFloat()
+    .escape()
+    .toFloat();
+
+export const progressValidator = checkMeasurementValue(body('progress'));
+export const valueValidator = checkMeasurementValue(body('value'));

--- a/public/openapi/v1.2.0.yaml
+++ b/public/openapi/v1.2.0.yaml
@@ -1,0 +1,325 @@
+swagger: "2.0"
+
+info:
+  title: OKR Tracker API
+  description: API for updating KPIs and key results.
+  version: 1.1.0
+  contact:
+    name: Dataspeilet
+    url: https://okr.oslo.systems
+    email: annemerete.pettersen@origo.oslo.kommune.no
+  license:
+    name: MIT
+    url: https://opensource.org/licenses/MIT
+schemes:
+  - https
+produces:
+  - application/json
+x-google-backend:
+  address: https://<location>-<project-id>.cloudfunctions.net/<CF-location>
+  path_translation: APPEND_PATH_TO_ADDRESS
+  protocol: h2
+security:
+  - api_key: []
+
+paths:
+  /kpi/{id}:
+    get:
+      summary: Get KPI.
+      operationId: getKPI
+      parameters:
+        - name: id
+          in: path
+          description: KPI Id
+          required: true
+          type: string
+      responses:
+        200:
+          description: A successful response
+          schema:
+            $ref: '#/definitions/Kpi'
+        404:
+          $ref: '#/responses/NotFound'
+        500:
+          $ref: '#/responses/Unavailable'
+    post:
+      summary: Post KPI progression.
+      operationId: postKPI
+      security:
+        - api_key: []
+      parameters:
+        - name: id
+          in: path
+          description: KPI Id
+          required: true
+          type: string
+        - name: progress
+          in: body
+          required: true
+          description: updated progress
+          schema:
+            type: number
+            example:
+              progress: 123
+        - name: okr-team-secret
+          in: header
+          description: Identify yourself with the secret you chose in your Team's settings
+          type: string
+      responses:
+        '200':
+          description: A successful response
+          schema:
+            type: string
+            example: "Updated KPI (${id}) with progress: ${progress}"
+        400:
+          $ref: '#/responses/BadRequest'
+        404:
+          $ref: '#/responses/NotFound'
+        500:
+          $ref: '#/responses/Unavailable'
+  /kpi/{id}/values:
+    get:
+      summary: Get KPI progression history.
+      operationId: getKPIProgressionValues
+      parameters:
+        - name: id
+          in: path
+          description: KPI Id
+          required: true
+          type: string
+      responses:
+        200:
+          description: A successful response
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/KpiMeasurement'
+        404:
+          $ref: '#/responses/NotFound'
+        500:
+          $ref: '#/responses/Unavailable'
+  /kpi/{id}/values/{date}:
+    parameters:
+      - name: id
+        in: path
+        description: KPI Id
+        required: true
+        type: string
+      - name: date
+        in: path
+        description: Date
+        required: true
+        type: string
+        format: date
+      - name: okr-team-secret
+        in: header
+        description: Identify yourself with the secret you chose in your Team's settings
+        type: string
+    put:
+      summary: Create or update KPI progression value.
+      operationId: updateKPIProgressionValue
+      parameters:
+        - name: value
+          in: body
+          required: true
+          description: Progression value
+          schema:
+            type: number
+            example:
+              progress: 123
+      responses:
+        200:
+          description: A successful response
+          schema:
+            type: object
+            properties:
+              message:
+                type: string
+        400:
+          $ref: '#/responses/BadRequest'
+        404:
+          $ref: '#/responses/NotFound'
+        500:
+          $ref: '#/responses/Unavailable'
+    delete:
+      summary: Delete KPI progression value.
+      operationId: deleteKPIProgressionValue
+      responses:
+        200:
+          description: A successful response
+          schema:
+            type: object
+            properties:
+              message:
+                type: string
+        400:
+          $ref: '#/responses/BadRequest'
+        404:
+          $ref: '#/responses/NotFound'
+        500:
+          $ref: '#/responses/Unavailable'
+  /keyres/{id}:
+    get:
+      summary: Get key result.
+      operationId: getKeyRes
+      security:
+        - api_key: []
+      parameters:
+        - name: id
+          in: path
+          description: Key result Id
+          required: true
+          type: string
+      responses:
+        '200':
+          description: A successful response
+          schema:
+            $ref: '#/definitions/Keyres'
+        404:
+          $ref: '#/responses/NotFound'
+        500:
+          $ref: '#/responses/Unavailable'
+    post:
+      summary: Post key result progression.
+      operationId: postKeyRes
+      security:
+        - api_key: []
+      parameters:
+        - name: id
+          in: path
+          description: Key res Id
+          required: true
+          type: string
+        - name: progress
+          in: body
+          required: true
+          description: updated progress
+          schema:
+            type: number
+            example:
+              progress: 123
+        - name: okr-team-secret
+          in: header
+          description: Identify yourself with the secret you chose in your Team's settings
+          type: string
+      responses:
+        '200':
+          description: A successful response
+          schema:
+            type: string
+            example: "Updated Key result (${id}) with progress: ${progress}"
+        400:
+          $ref: '#/responses/BadRequest'
+        404:
+          $ref: '#/responses/NotFound'
+        500:
+          $ref: '#/responses/Unavailable'
+
+securityDefinitions:
+  api_key:
+    type: "apiKey"
+    name: "x-api-key"
+    in: "header"
+
+definitions:
+  Keyres:
+    properties:
+      currentValue:
+        type: number
+      progression:
+        type: number
+      description:
+        type: string
+      created:
+        type: string
+        format: date-time
+      edited:
+        type: string
+        format: date-time
+      createdBy:
+        type: string
+      editedBy:
+        type: string
+      lastUpdated:
+        type: object
+        properties:
+          value:
+            type: number
+          timestamp:
+            type: string
+            format: date-time
+          comment:
+            type: string
+          createdBy:
+            type: string
+  Kpi:
+    properties:
+      currentValue:
+        type: number
+      name:
+        type: string
+      type:
+        type: string
+      created:
+        type: string
+        format: date-time
+      edited:
+        type: string
+        format: date-time
+      createdBy:
+        type: string
+      editedBy:
+        type: string
+      lastUpdated:
+        type: object
+        properties:
+          value:
+            type: number
+          timestamp:
+            type: string
+            format: date-time
+  KpiMeasurement:
+    type: object
+    properties:
+      value:
+        type: number
+      date:
+        type: string
+        format: date
+      comment:
+        type: string
+      created:
+        type: string
+        format: date-time
+      createdBy:
+        type: string
+      edited:
+        type: string
+        format: date-time
+      editedBy:
+        type: string
+
+responses:
+  NotFound:
+    description: Resource not found
+    schema:
+      type: object
+      properties:
+        message:
+          type: string
+  Unavailable:
+    description: Something went wrong
+    schema:
+      type: object
+      properties:
+        message:
+          type: string
+  BadRequest:
+    description: A bad request
+    schema:
+      type: object
+      properties:
+        errors:
+          type: object
+        message:
+          type: string

--- a/src/components/DashboardResultIndicatorsSection.vue
+++ b/src/components/DashboardResultIndicatorsSection.vue
@@ -179,6 +179,19 @@ export default {
     tabIds() {
       return tabIdsHelper('resultIndicator');
     },
+    filteredProgress() {
+      // Filter out any duplicate measurement values for each date
+      const seenDates = [];
+
+      return this.progressCollection.filter((a) => {
+        const date = a.timestamp.toDate().toISOString().slice(0, 10);
+        if (!seenDates.includes(date)) {
+          seenDates.push(date);
+          return true;
+        }
+        return false;
+      });
+    },
   },
 
   watch: {
@@ -310,7 +323,7 @@ export default {
      * Return the start date of `period`. If unset, the earliest date
      * found in `progress` is returned instead.
      */
-    getStartDate (period, progress) {
+    getStartDate(period, progress) {
       if (period.startDate) {
         const ts = Timestamp.fromDate(period.startDate);
         return ts.toDate ? ts.toDate() : new Date(period.ts);
@@ -323,7 +336,7 @@ export default {
      * Return the end date of `period`. If unset, the last date found in
      * `progress` is returned instead.
      */
-    getEndDate (period, progress) {
+    getEndDate(period, progress) {
       if (period.endDate) {
         const ts = Timestamp.fromDate(period.endDate);
         return ts.toDate ? ts.toDate() : new Date(ts);
@@ -350,7 +363,7 @@ export default {
       this.graph.render({
         startDate: this.startDate,
         endDate: this.endDate,
-        progress: this.progressCollection,
+        progress: this.filteredProgress,
         kpi: kpis[this.activeTab],
         theme: this.theme,
       });
@@ -372,11 +385,11 @@ export default {
         const formattedPeriod = periodDates({
           startDate: this.getStartDate(
             this.currentResultIndicatorPeriod,
-            this.progressCollection
+            this.filteredProgress
           ),
           endDate: this.getEndDate(
             this.currentResultIndicatorPeriod,
-            this.progressCollection
+            this.filteredProgress
           ),
         });
 
@@ -395,7 +408,7 @@ export default {
             i18n.t('fields.comment'),
           ]),
           csvFormatBody(
-            this.progressCollection.map((d) => [
+            this.filteredProgress.map((d) => [
               d.value,
               d.timestamp.toDate().toISOString(),
               d.comment,

--- a/src/components/modals/KPIProgressModal.vue
+++ b/src/components/modals/KPIProgressModal.vue
@@ -1,0 +1,118 @@
+<template>
+  <modal-wrapper v-if="record" @close="close">
+    <template #header>
+      {{ $t('tooltip.editProgress') }}
+    </template>
+
+    <validation-observer v-slot="{ handleSubmit }">
+      <form id="progress-value" @submit.prevent="handleSubmit(update)">
+        <form-component
+          v-model="thisRecord.value"
+          input-type="input"
+          name="name"
+          :label="$t('widget.history.value')"
+          rules="required"
+          type="number"
+          data-cy="progress_value"
+        />
+
+        <validation-provider v-slot="{ errors }" name="date" rules="required">
+          <label class="form-field">
+            <span class="form-label">{{ $t('widget.history.date') }}</span>
+            <flat-pickr
+              v-model="thisRecord.timestamp"
+              :config="flatPickerConfig"
+              class="form-control flatpickr-input"
+              name="date"
+              @on-change="onDateSelected"
+            />
+            <span class="form-field--error">{{ errors[0] }}</span>
+          </label>
+        </validation-provider>
+
+        <form-component
+          v-model="thisRecord.comment"
+          input-type="textarea"
+          name="comment"
+          :label="$t('widget.history.comment_optional')"
+          :placeholder="$t('keyResult.commentPlaceholder')"
+          type="number"
+          data-cy="progress_comment"
+        />
+      </form>
+    </validation-observer>
+
+    <div
+      v-if="existingValue"
+      class="ok-alert ok-alert--warning"
+      style="background: var(--color-warning)"
+    >
+      {{
+        $t('widget.history.overwriteWarning', {
+          date: dateShort(existingValue.timestamp.toDate()),
+          value: formatKPIValue(activeKpi, existingValue.value),
+        })
+      }}
+    </div>
+
+    <template #footer>
+      <button form="progress-value" :disabled="loading" class="btn btn--ods">
+        {{ $t('btn.saveChanges') }}
+      </button>
+    </template>
+  </modal-wrapper>
+</template>
+
+<script>
+import { mapState } from 'vuex';
+import locale from 'flatpickr/dist/l10n/no';
+import { db } from '@/config/firebaseConfig';
+import Progress from '@/db/Progress';
+import { dateShort } from '@/util';
+import { formatKPIValue } from '@/util/kpiHelpers';
+import ProgressModal from './ProgressModal.vue';
+
+export default {
+  name: 'KPIProgressModal',
+  extends: ProgressModal,
+
+  data: () => ({
+    existingValue: null,
+    flatPickerConfig: {
+      altFormat: 'j M Y H:i:S',
+      altInput: false,
+      enableTime: false,
+      locale: locale.no,
+      maxDate: new Date(),
+      minDate: null,
+      mode: 'single',
+      inline: true,
+    },
+  }),
+
+  computed: {
+    ...mapState(['activeKpi']),
+  },
+
+  methods: {
+    dateShort,
+    formatKPIValue,
+
+    async onDateSelected() {
+      if (!this.activeKpi) {
+        return;
+      }
+      const existingValueSnapshot = await Progress.get(
+        db.collection('kpis'),
+        this.activeKpi.id,
+        new Date(this.thisRecord.timestamp)
+      );
+
+      this.existingValue =
+        existingValueSnapshot && existingValueSnapshot.id !== this.record.id
+          ? existingValueSnapshot.data()
+          : null;
+    },
+  },
+};
+</script>

--- a/src/components/modals/ProgressModal.vue
+++ b/src/components/modals/ProgressModal.vue
@@ -78,12 +78,14 @@ export default {
     flatPickerConfig: {
       altFormat: 'j M Y H:i:S',
       altInput: false,
-      enableSeconds: true,
       enableTime: true,
+      enableSeconds: true,
+      minuteIncrement: 1,
       locale: locale.no,
       maxDate: new Date(),
       minDate: null,
       mode: 'single',
+      inline: true,
     },
   }),
 
@@ -122,3 +124,22 @@ export default {
   },
 };
 </script>
+
+<style lang="scss" scoped>
+input[name='date'] {
+  display: none;
+}
+
+// Set specific width in order to match inlined datepicker.
+// TODO: Allow specyfing set sizes for modals in the future,
+// eg. wide, narrow, to keep these somewhat aligned.
+::v-deep .modal {
+  width: 341px;
+}
+
+::v-deep .flatpickr-calendar {
+  border-radius: 0;
+  -webkit-box-shadow: none;
+  box-shadow: none;
+}
+</style>

--- a/src/components/widgets/WidgetProgressHistory/WidgetProgressHistory.vue
+++ b/src/components/widgets/WidgetProgressHistory/WidgetProgressHistory.vue
@@ -47,7 +47,7 @@
         <tbody>
           <tr v-for="record in limitedProgress" :key="record.id">
             <td>{{ valueFormatter(record.value) }}</td>
-            <td>{{ dateTimeShort(record.timestamp.toDate()) }}</td>
+            <td>{{ dateFormatter(record.timestamp.toDate()) }}</td>
             <td v-if="hasAnyChangedBy">
               <user-link
                 v-if="record.editedBy || record.createdBy"
@@ -161,6 +161,11 @@ export default {
       type: Function,
       required: false,
       default: (value) => value,
+    },
+    dateFormatter: {
+      type: Function,
+      required: false,
+      default: dateTimeShort,
     },
     noValuesMessage: {
       type: String,

--- a/src/components/widgets/WidgetProgressHistory/WidgetProgressHistory.vue
+++ b/src/components/widgets/WidgetProgressHistory/WidgetProgressHistory.vue
@@ -113,8 +113,9 @@
       {{ $t('btn.showMore') }}
     </button>
 
-    <progress-modal
-      v-if="showValueModal"
+    <component
+      :is="valueModal"
+      v-if="valueModal && showValueModal"
       :record="chosenProgressRecord"
       @close="closeValueModal"
       @update-record="
@@ -172,6 +173,7 @@ export default {
     historyLimit: 10,
     showComments: true,
     showProfileModal: false,
+    valueModal: null,
     showValueModal: false,
     chosenProgressRecord: null,
     chosenProfileId: null,
@@ -184,16 +186,26 @@ export default {
       return this.progress.find(({ comment }) => comment) !== undefined;
     },
     hasAnyChangedBy() {
-      return this.progress.find(({
-        createdBy,
-        editedBy,
-      }) => createdBy || editedBy) !== undefined;
+      return (
+        this.progress.find(
+          ({ createdBy, editedBy }) => createdBy || editedBy
+        ) !== undefined
+      );
     },
     limitedProgress() {
       return this.historyLimit
         ? this.progress.slice(0, this.historyLimit)
         : this.progress;
     },
+  },
+
+  mounted() {
+    if (this.$route.name === 'KpiHome') {
+      this.valueModal = () =>
+        import('@/components/modals/KPIProgressModal.vue');
+    } else {
+      this.valueModal = () => import('@/components/modals/ProgressModal.vue');
+    }
   },
 
   methods: {

--- a/src/locale/locales/en-US.json
+++ b/src/locale/locales/en-US.json
@@ -461,7 +461,8 @@
       "empty": {
         "heading": "No history",
         "body": "No values registered for this item."
-      }
+      },
+      "overwriteWarning": "Note: This change will overwrite existing value for chosen date ({date}): {value}."
     }
   },
   "error": {

--- a/src/locale/locales/nb-NO.json
+++ b/src/locale/locales/nb-NO.json
@@ -459,7 +459,8 @@
       "empty": {
         "heading": "Ingen historikk",
         "body": "Ingen verdier registrert for dette elementet."
-      }
+      },
+      "overwriteWarning": "Merk: Denne endringen overskriver eksisterende måleverdi for valgt dato ({date}): {value}."
     }
   },
   "error": {

--- a/src/views/Api.vue
+++ b/src/views/Api.vue
@@ -15,7 +15,7 @@ export default {
 
   mounted() {
     SwaggerUi({
-      url: './openapi/v1.1.1.yaml',
+      url: './openapi/v1.2.0.yaml',
       dom_id: '#swagger-ui',
     });
   },

--- a/src/views/KpiHome.vue
+++ b/src/views/KpiHome.vue
@@ -208,6 +208,19 @@ export default {
             a.timestamp.toDate() < this.endDate
         );
       }
+
+      // Filter out any duplicate measurement values for each date
+      const seenDates = [];
+
+      this.filteredProgress = this.filteredProgress.filter((a) => {
+        const date = a.timestamp.toDate().toISOString().slice(0, 10);
+        if (!seenDates.includes(date)) {
+          seenDates.push(date);
+          return true;
+        }
+        return false;
+      });
+
       this.renderGraph();
     },
 

--- a/src/views/KpiHome.vue
+++ b/src/views/KpiHome.vue
@@ -57,6 +57,7 @@
           :progress="filteredProgress"
           :is-loading="isLoading"
           :value-formatter="_formatKPIValue"
+          :date-formatter="dateShort"
           :no-values-message="$t('empty.noKPIProgress')"
           @update-record="updateHistoryRecord"
           @delete-record="deleteHistoryRecord"
@@ -80,7 +81,7 @@ import { endOfDay } from 'date-fns';
 import { db } from '@/config/firebaseConfig';
 import Progress from '@/db/Progress';
 import LineChart from '@/util/LineChart';
-import { dateTimeShort, formatISOShort } from '@/util';
+import { dateShort, formatISOShort } from '@/util';
 import { formatKPIValue } from '@/util/kpiHelpers';
 import WidgetMissionStatement from '@/components/widgets/WidgetMissionStatement.vue';
 import WidgetTeam from '@/components/widgets/WidgetTeam/WidgetTeam.vue';
@@ -142,7 +143,7 @@ export default {
   },
 
   methods: {
-    dateTimeShort,
+    dateShort,
     formatKPIValue,
 
     async updateHistoryRecord(id, data, modalCloseHandler) {


### PR DESCRIPTION
* Only a single daily progression value is now enforced
* Adds new API endpoints for updating and deleting KPI progression values
* Updates the frontend to account for these changes, e.g. the modal for editing values:
<img width="336" alt="image" src="https://user-images.githubusercontent.com/2866225/195300122-5061242e-f35c-413e-86fe-04cdae4893f7.png">

