### PR TITLE
Fix period selector rendering on Safari

### DIFF
--- a/src/components/DashboardPeriodSelector.vue
+++ b/src/components/DashboardPeriodSelector.vue
@@ -142,10 +142,10 @@ export default {
 
 .periodSelector__input {
   display: flex;
-  align-items: center;
   gap: 0.5rem;
-  white-space: nowrap;
+  align-items: center;
   padding: 0.75rem;
+  white-space: nowrap;
   border: 1px solid var(--color-grey-100);
   cursor: pointer;
 
@@ -180,6 +180,12 @@ export default {
       border-left: 0;
       border-radius: 0;
       box-shadow: none;
+
+      &::before,
+      &::after {
+        // Hide flatpickr arrow
+        display: none;
+      }
     }
     &-input {
       display: none;
@@ -189,6 +195,7 @@ export default {
 
 .periodSelector__option {
   width: 100%;
+  margin: 0;
   padding: 1rem;
   color: var(--color-grey-400);
   font-weight: 500;


### PR DESCRIPTION
<img width="300" alt="image" src="https://user-images.githubusercontent.com/2866225/195347668-9b843e1a-77eb-44e8-bc87-676e41199d78.png">
=>
<img width="300" alt="image" src="https://user-images.githubusercontent.com/2866225/195347539-f63d097b-0ffa-4418-bd85-919c2b08d36d.png">
