### PR TITLE
Drop `operator-assignment` rule to silence ESLint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,7 +15,6 @@ module.exports = {
     'func-names': 'off',
     'no-restricted-syntax': 'off',
     'import/extensions': [0, 'never'],
-    'operator-assignment': ['error', 'never'],
     'prefer-destructuring': 'off',
     'no-underscore-dangle': 'off',
   },


### PR DESCRIPTION
Operator assignments are already used in some places throughout the code, so this rule has been causing noise for some time.