### PR TITLE
Increase line chart height for dashboard and tracker

### DIFF
--- a/src/components/DashboardResultIndicatorsSection.vue
+++ b/src/components/DashboardResultIndicatorsSection.vue
@@ -336,7 +336,7 @@ export default {
     renderGraph() {
       if (!this.graph && this.resultIndicators.length) {
         this.graph = new LineChart(this.$refs.progressGraphSvg, {
-          height: 350,
+          height: 450,
           tooltips: true,
         });
       }

--- a/src/util/LineChart/index.js
+++ b/src/util/LineChart/index.js
@@ -35,7 +35,7 @@ export default class LineChart {
 
     select(svgElement).call(initSvg.bind(this));
 
-    this.height = height || 250;
+    this.height = height || 350;
     this.x = scaleTime().clamp(true);
     this.y = scaleLinear().nice();
 


### PR DESCRIPTION
The line chart height is now `450` for the dashboard while defaulting to `350` (affects the tracker, KPI/KR).