### PR TITLE
Initial support for graph target line and legend

### DIFF
--- a/src/components/DashboardResultIndicatorsSection.vue
+++ b/src/components/DashboardResultIndicatorsSection.vue
@@ -350,7 +350,8 @@ export default {
 
       if (!this.graph) {
         this.graph = new LineChart(this.$refs.progressGraphSvg, {
-          height: 450,
+          height: 550,
+          legend: true,
           tooltips: true,
         });
       }
@@ -504,7 +505,7 @@ export default {
 }
 
 .progressGraph {
-  padding: 1rem 1.5rem 1.5rem 0.25rem;
+  padding: 1rem 1.5rem 0 0.25rem;
 }
 
 .progressTarget {

--- a/src/locale/locales/en-US.json
+++ b/src/locale/locales/en-US.json
@@ -143,7 +143,9 @@
     "departmentObjectives": "Department objectives",
     "departmentAbout": "About",
     "dashboardEntry": "Go to dashboard",
-    "keyFigures": "KPIs"
+    "keyFigures": "KPIs",
+    "value": "Value",
+    "target": "Target"
   },
   "btn": {
     "close": "Close",

--- a/src/locale/locales/nb-NO.json
+++ b/src/locale/locales/nb-NO.json
@@ -115,7 +115,6 @@
     "admin": "Admin",
     "administration": "Administrasjon",
     "superAdmin": "Super admin",
-
     "signOut": "Logg ut",
     "createdBy": "Opprettet av",
     "lastUpdate": "Sist oppdatert",
@@ -141,7 +140,9 @@
     "departmentObjectives": "Områdets mål",
     "departmentAbout": "Om produktområdet",
     "dashboardEntry": "Se dashboard",
-    "keyFigures": "KPI-er"
+    "keyFigures": "KPI-er",
+    "value": "Verdi",
+    "target": "Målsetting"
   },
   "btn": {
     "close": "Lukk",

--- a/src/util/LineChart/linechart-helpers.js
+++ b/src/util/LineChart/linechart-helpers.js
@@ -165,7 +165,7 @@ export function populateLegend(el) {
     .style('text-anchor', 'start')
     .style('font-size', '14px')
     .style('font-family', '"OsloSans", Helvetica, Arial, sans-serif')
-    .style('color', 'var(--color-grey-700)');
+    .style('fill', 'var(--color-grey-700)');
 
   item.attr('transform', (d, i) => {
     const x = sum(item.data(), (e, j) => {


### PR DESCRIPTION
`LineChart.render` now supports a `target` property which accepts a list of "targets", e.g populated from a future KPI subcollection `targets`. In addition, an optional legend is drawn to the graph.
```js
targets: [
  { value: 0.6, startDate: new Date('2022-03-01'), endDate: new Date('2022-08-01') },
  { value: 0.75, startDate: new Date('2022-09-01'), endDate: new Date('2022-12-01') },
]
```
<img width="1206" alt="image" src="https://user-images.githubusercontent.com/2866225/197211042-9e4aa562-f649-4f18-a834-642d93448374.png">
