### PR TITLE
Keep comments when updating KPI progression values using the API

### DIFF
--- a/functions/api/helpers.js
+++ b/functions/api/helpers.js
@@ -49,10 +49,11 @@ export async function updateKPIProgressionValue(kpiRef, date, value) {
   };
 
   if (!valuesSnapshot.empty) {
-    const { created, createdBy } = valuesSnapshot.docs[0].data();
+    const { comment, created, createdBy } = valuesSnapshot.docs[0].data();
 
     data = {
       ...data,
+      comment: comment || null,
       created: created || null,
       createdBy: createdBy || null,
       edited: new Date(),


### PR DESCRIPTION
This should apply both to the existing POST-endpoint and the new PUT-endpoint.