### PR TITLE
Reusable form buttons

### DIFF
--- a/src/components/UserProfileMenu.vue
+++ b/src/components/UserProfileMenu.vue
@@ -31,13 +31,11 @@
         </label>
       </validation-observer>
 
-      <button
-        class="btn btn--icon btn--pri btn--icon-pri profileModal__save-button"
+      <btn-save
         form="updateUser"
+        class="profileModal__save-button"
         :disabled="loading"
-      >
-        <span class="icon fa fa-fw fa-save"></span> {{ $t('btn.save') }}
-      </button>
+      />
 
       <hr class="divider" />
 
@@ -97,12 +95,14 @@
   import ThemeToggle from '@/components/ThemeToggle.vue';
   import User from '@/db/User';
   import { jobPositions } from '@/config/jobPositions';
+  import { BtnSave } from '@/components/generic/form/buttons';
 
   export default {
     name: 'UserProfileMenu',
 
     components: {
       ThemeToggle,
+      BtnSave,
     },
 
     props: {
@@ -286,11 +286,6 @@
     @media screen and (min-width: bp(m)) {
       display: none;
     }
-  }
-
-  .btn--pri {
-    color: var(--color-text);
-    background: var(--color-green);
   }
 </style>
 <style lang="scss">

--- a/src/components/generic/form/buttons/Btn.vue
+++ b/src/components/generic/form/buttons/Btn.vue
@@ -1,0 +1,70 @@
+<template>
+  <button
+    :form="form"
+    :aria-label="label"
+    :class="['btn', { 'btn--icon': icon }, buttonVariantClass]"
+    :disabled="disabled"
+    @click="$emit('click', $event)"
+  >
+    <i v-if="icon" :class="['icon', 'fa', 'fa-fw', `fa-${icon}`]" />
+    <span v-if="!hideLabel">{{ label }}</span>
+  </button>
+</template>
+
+<script>
+export default {
+  name: 'ButtonSave',
+
+  props: {
+    form: {
+      type: String,
+      required: false,
+      default: null,
+    },
+    label: {
+      type: String,
+      required: true,
+      default: null,
+    },
+    hideLabel: {
+      type: Boolean,
+      required: false,
+      default: false,
+    },
+    variant: {
+      type: String,
+      required: false,
+      default: 'primary',
+    },
+    icon: {
+      type: String,
+      required: false,
+      default: null,
+    },
+    disabled: {
+      type: Boolean,
+      required: false,
+      default: false,
+    },
+  },
+
+  computed: {
+    buttonVariantClass() {
+      switch (this.variant) {
+        case 'primary':
+          return 'btn--pri';
+        case 'secondary':
+          return 'btn--sec';
+        case 'tertiary':
+          return 'btn--ter';
+        case 'confirm':
+          return 'btn--confirm';
+        case 'ghost':
+          return 'btn--ghost';
+        default:
+          return 'btn--pri';
+      }
+    },
+  },
+};
+</script>

--- a/src/components/generic/form/buttons/BtnDelete.vue
+++ b/src/components/generic/form/buttons/BtnDelete.vue
@@ -1,0 +1,64 @@
+<template>
+  <v-popover offset="0" placement="top">
+    <btn
+      :form="form"
+      :icon="icon"
+      :label="label"
+      :hide-label="hideLabel"
+      :variant="variant"
+      :disabled="disabled"
+    />
+
+    <template slot="popover">
+      <btn
+        variant="tertiary"
+        class="btn--negative"
+        :label="confirmLabel"
+        @click="$emit('click', $event)"
+      />
+    </template>
+  </v-popover>
+</template>
+
+<script>
+import { VPopover } from 'v-tooltip';
+import Btn from './Btn.vue';
+
+export default {
+  name: 'ButtonDelete',
+
+  components: {
+    VPopover,
+    Btn,
+  },
+
+  extends: Btn,
+
+  props: {
+    label: {
+      type: String,
+      required: false,
+      default() {
+        return this.$t('btn.delete');
+      },
+    },
+    confirmLabel: {
+      type: String,
+      required: false,
+      default() {
+        return this.$t('btn.confirmDelete');
+      },
+    },
+    variant: {
+      type: String,
+      required: false,
+      default: 'tertiary',
+    },
+    icon: {
+      type: String,
+      required: false,
+      default: 'trash',
+    },
+  },
+};
+</script>

--- a/src/components/generic/form/buttons/BtnSave.vue
+++ b/src/components/generic/form/buttons/BtnSave.vue
@@ -1,0 +1,28 @@
+<script>
+import Btn from './Btn.vue';
+
+export default {
+  name: 'BtnSave',
+  extends: Btn,
+
+  props: {
+    label: {
+      type: String,
+      required: false,
+      default() {
+        return this.$t('btn.save');
+      },
+    },
+    variant: {
+      type: String,
+      required: false,
+      default: 'confirm',
+    },
+    icon: {
+      type: String,
+      required: false,
+      default: 'save',
+    },
+  },
+};
+</script>

--- a/src/components/generic/form/buttons/index.js
+++ b/src/components/generic/form/buttons/index.js
@@ -1,0 +1,5 @@
+import Btn from './Btn.vue';
+import BtnDelete from './BtnDelete.vue';
+import BtnSave from './BtnSave.vue';
+
+export { Btn, BtnDelete, BtnSave };

--- a/src/components/modals/AddKPIModal.vue
+++ b/src/components/modals/AddKPIModal.vue
@@ -152,9 +152,13 @@
     </validation-observer>
 
     <template #footer>
-      <button form="addKpi" :disabled="loading" class="btn btn--pri">
-        {{ $t('btn.add') }}
-      </button>
+      <btn-save
+        form="addKpi"
+        variant="primary"
+        class="profileModal__save-button"
+        :label="$t('btn.add')"
+        :disabled="loading"
+      />
     </template>
   </modal-wrapper>
 </template>
@@ -164,12 +168,14 @@ import { mapState } from 'vuex';
 import { kpiFormats, kpiTypes } from '@/util/kpiHelpers';
 import Kpi from '@/db/Kpi';
 import ModalWrapper from './ModalWrapper.vue';
+import { BtnSave } from '@/components/generic/form/buttons';
 
 export default {
   name: 'AddKPIModal',
 
   components: {
     ModalWrapper,
+    BtnSave,
   },
 
   data: () => ({
@@ -224,9 +230,3 @@ export default {
   },
 };
 </script>
-
-<style lang="scss" scoped>
-.btn--space {
-  margin-left: 1rem;
-}
-</style>

--- a/src/components/modals/KPIProgressModal.vue
+++ b/src/components/modals/KPIProgressModal.vue
@@ -71,9 +71,11 @@
     </div>
 
     <template #footer>
-      <button form="progress-value" :disabled="loading" class="btn btn--ods">
-        {{ $t(record ? 'btn.saveChanges' : 'btn.save') }}
-      </button>
+      <btn-save
+        form="progress-value"
+        :label="$t(record ? 'btn.saveChanges' : 'btn.save')"
+        :disabled="loading"
+      />
     </template>
   </modal-wrapper>
 </template>

--- a/src/components/modals/KeyResultModal.vue
+++ b/src/components/modals/KeyResultModal.vue
@@ -33,9 +33,7 @@
     </validation-observer>
 
     <template #footer>
-      <button form="modal" :disabled="loading" class="btn btn--ods">
-        {{ $t('btn.saveChanges') }}
-      </button>
+      <btn-save form="modal" :disabled="loading" />
     </template>
   </modal-wrapper>
 </template>
@@ -44,12 +42,14 @@
 import { db } from '@/config/firebaseConfig';
 import Progress from '@/db/Progress';
 import ModalWrapper from './ModalWrapper.vue';
+import { BtnSave } from '@/components/generic/form/buttons';
 
 export default {
   name: 'KeyResultModal',
 
   components: {
     ModalWrapper,
+    BtnSave,
   },
 
   props: {

--- a/src/components/modals/ProfileModal.vue
+++ b/src/components/modals/ProfileModal.vue
@@ -34,14 +34,12 @@
           </div>
         </label>
 
-        <button
+        <btn-save
           v-if="me || $store.state.user.superAdmin"
-          class="btn btn--pri profileModal__save-button"
           form="updateUser"
+          class="profileModal__save-button"
           :disabled="loading"
-        >
-          {{ $t('btn.save') }}
-        </button>
+        />
       </div>
 
       <div class="column">
@@ -66,12 +64,14 @@ import { db, auth } from '@/config/firebaseConfig';
 import User from '@/db/User';
 import { jobPositions } from '@/config/jobPositions';
 import ModalWrapper from './ModalWrapper.vue';
+import { BtnSave } from '@/components/generic/form/buttons';
 
 export default {
   name: 'ProfileModal',
 
   components: {
     ModalWrapper,
+    BtnSave,
   },
 
   props: {

--- a/src/components/modals/ProgressModal.vue
+++ b/src/components/modals/ProgressModal.vue
@@ -57,9 +57,11 @@
     </validation-observer>
 
     <template #footer>
-      <button form="progress-value" :disabled="loading" class="btn btn--pri">
-        {{ $t(record ? 'btn.saveChanges' : 'btn.save') }}
-      </button>
+      <btn-save
+        form="progress-value"
+        :label="$t(record ? 'btn.saveChanges' : 'btn.save')"
+        :disabled="loading"
+      />
     </template>
   </modal-wrapper>
 </template>
@@ -67,12 +69,14 @@
 <script>
 import locale from 'flatpickr/dist/l10n/no';
 import ModalWrapper from './ModalWrapper.vue';
+import { BtnSave } from '@/components/generic/form/buttons';
 
 export default {
   name: 'ProgressModal',
 
   components: {
     ModalWrapper,
+    BtnSave,
   },
 
   props: {

--- a/src/components/widgets/WidgetProgressHistory/WidgetProgressHistory.vue
+++ b/src/components/widgets/WidgetProgressHistory/WidgetProgressHistory.vue
@@ -74,30 +74,19 @@
             </td>
             <td v-if="hasEditRights">
               <div class="record__actions">
-                <button
+                <btn
                   v-tooltip="$t('tooltip.editProgress')"
-                  class="btn btn--icon btn--ter"
+                  icon="edit"
+                  :label="$t('tooltip.editProgress')"
+                  :hide-label="true"
+                  variant="tertiary"
                   @click="openValueModal(record)"
-                >
-                  <i class="fa fa-edit" />
-                </button>
-                <v-popover offset="0" placement="top">
-                  <button
-                    v-tooltip="$t('tooltip.deleteProgress')"
-                    class="btn btn--icon btn--ter"
-                  >
-                    <i class="fa fa-trash" />
-                  </button>
-
-                  <template slot="popover">
-                    <button
-                      class="btn btn--ter btn--negative"
-                      @click="$emit('delete-record', record.id)"
-                    >
-                      {{ $t('btn.confirmDeleteProgress') }}
-                    </button>
-                  </template>
-                </v-popover>
+                />
+                <btn-delete
+                  v-tooltip="$t('tooltip.deleteProgress')"
+                  :hide-label="true"
+                  @click="$emit('delete-record', record.id)"
+                />
               </div>
             </td>
           </tr>
@@ -133,9 +122,9 @@
 
 <script>
 import { mapGetters } from 'vuex';
-import { VPopover } from 'v-tooltip';
 import { dateTimeShort } from '@/util';
 import UserLink from './UserLink.vue';
+import { Btn, BtnDelete } from '@/components/generic/form/buttons';
 
 export default {
   name: 'KeyResultHome',
@@ -145,7 +134,8 @@ export default {
     ProfileModal: () => import('@/components/modals/ProfileModal.vue'),
     ProgressModal: () => import('@/components/modals/ProgressModal.vue'),
     UserLink,
-    VPopover,
+    Btn,
+    BtnDelete,
   },
 
   props: {

--- a/src/locale/locales/en-US.json
+++ b/src/locale/locales/en-US.json
@@ -169,7 +169,7 @@
     "minimize": "Minimize",
     "expand": "Expand",
     "restore": "Restore",
-    "confirmDeleteProgress": "Confirm delete",
+    "confirmDelete": "Confirm delete",
     "reset": "Reset",
     "showMore": "Show more",
     "syncData": "Synchronize data"

--- a/src/locale/locales/nb-NO.json
+++ b/src/locale/locales/nb-NO.json
@@ -165,7 +165,7 @@
     "minimize": "Minimer",
     "expand": "Ekspander",
     "restore": "Gjenopprett",
-    "confirmDeleteProgress": "Bekreft sletting",
+    "confirmDelete": "Bekreft sletting",
     "reset": "Nullstill",
     "showMore": "Vis mer",
     "syncData": "Synkroniser data"

--- a/src/styles/_buttons.scss
+++ b/src/styles/_buttons.scss
@@ -6,9 +6,10 @@
 .button-row {
   display: flex;
   flex-wrap: wrap;
+  justify-content: flex-end;
   margin: 2.5rem -0.25rem -0.25rem;
 
-  > .btn {
+  .btn {
     margin: 0.25rem;
   }
 }
@@ -16,7 +17,7 @@
 .btn {
   display: inline-flex;
   align-items: center;
-  padding: 0.75rem 0.5rem;
+  padding: 0.75rem;
   color: var(--color-text);
   font-weight: 500;
   font-size: 1rem;
@@ -35,11 +36,6 @@
     opacity: 0.6;
     filter: saturate(0.5);
   }
-}
-
-.btn--danger {
-  color: var(--color-red-dark);
-  background: var(--color-red-light);
 }
 
 .btn--pri {
@@ -62,6 +58,16 @@
   }
 }
 
+.btn--confirm {
+  color: var(--color-text);
+  background: var(--color-green);
+
+  &:hover {
+    color: var(--color-text-secondary);
+    background-color: var(--color-hover);
+  }
+}
+
 .btn--ods {
   color: var(--color-text-secondary);
   background: var(--color-primary);
@@ -69,13 +75,8 @@
 }
 
 .btn--icon {
+  gap: 0.5rem;
   justify-content: flex-start;
-  padding-right: 1rem;
-  color: var(--color-text);
-
-  & > .icon {
-    margin-right: 0.25rem;
-  }
 }
 
 .btn--icon-pri {

--- a/src/views/Admin/components/EditUser.vue
+++ b/src/views/Admin/components/EditUser.vue
@@ -46,18 +46,15 @@
     </div>
 
     <div class="selected-user__footer button-row">
-      <button
-        class="btn btn--delete-user"
+      <btn-delete
         :disabled="user.email === selectedUser.email || loading"
         @click="remove(selectedUser)"
-      >
-        <i class="icon fa fa-fw fa-trash" />
-        {{ $t('btn.deleteUser') }}
-      </button>
-      <button class="btn btn--pri" form="user-form" :disabled="loading">
-        <i class="icon fa fa-fw fa-save" />
-        {{ $t('btn.saveChanges') }}
-      </button>
+      />
+      <btn-save
+        form="user-form"
+        :label="$t('btn.saveChanges')"
+        :disabled="loading"
+      />
     </div>
   </div>
 </template>
@@ -66,9 +63,15 @@
 import { mapState } from 'vuex';
 import User from '@/db/User';
 import { db } from '@/config/firebaseConfig';
+import { BtnSave, BtnDelete } from '@/components/generic/form/buttons';
 
 export default {
   name: 'EditUser',
+
+  components: {
+    BtnSave,
+    BtnDelete,
+  },
 
   props: {
     selectedUser: {
@@ -169,20 +172,5 @@ export default {
   object-fit: cover;
   background: white;
   border-radius: 2rem;
-}
-
-.btn--pri {
-  color: var(--color-text);
-  background: var(--color-green);
-}
-
-.btn--delete-user {
-  color: var(--color-text);
-  background: transparent;
-}
-
-.button-row {
-  display: flex;
-  justify-content: flex-end;
 }
 </style>

--- a/src/views/ItemAdmin/ItemAdminGeneral.vue
+++ b/src/views/ItemAdmin/ItemAdminGeneral.vue
@@ -78,14 +78,12 @@
     </validation-observer>
 
     <div class="button-row">
-      <button v-if="!activeItem.archived" class="btn btn--icon btn--archive" :disabled="loading" @click="archive">
-        <i class="icon fa fa-fw fa-trash" />
-        {{ $t('btn.delete') }}
-      </button>
-      <button class="btn btn--icon btn--pri btn--icon-pri" form="update-item" :disabled="loading">
-        <i class="icon fa fa-fw fa-save" />
-        {{ $t('btn.saveChanges') }}
-      </button>
+      <btn-delete
+        v-if="!activeItem.archived"
+        :disabled="loading"
+        @click="archive"
+      />
+      <btn-save form="update-item" :disabled="loading" />
     </div>
   </div>
 </template>
@@ -97,12 +95,15 @@ import Department from '@/db/Department';
 import Product from '@/db/Product';
 import { db } from '@/config/firebaseConfig';
 import { toastArchiveAndRevert } from '@/util';
+import { BtnSave, BtnDelete } from '@/components/generic/form/buttons';
 
 export default {
   name: 'ItemAdminGeneral',
 
   components: {
     ArchivedRestore: () => import('@/components/ArchivedRestore.vue'),
+    BtnSave,
+    BtnDelete,
   },
 
   data: () => ({
@@ -237,21 +238,6 @@ export default {
 
   @media screen and (min-width: bp(xl)) {
     width: span(6, 0, span(10));
-  }
-
-  .btn--pri {
-    color: var(--color-text);
-    background: var(--color-green);
-  }
-
-  .btn--archive {
-    color: var(--color-text);
-    background: transparent;
-  }
-
-  .button-row {
-    display: flex;
-    justify-content: flex-end;
   }
 }
 </style>

--- a/src/views/ItemAdmin/ItemAdminKPI.vue
+++ b/src/views/ItemAdmin/ItemAdminKPI.vue
@@ -147,16 +147,13 @@
             <span class="form-help">Push updates with curl</span>
           </template>
         </form-component>
-
-        <div class="button-row">
-          <button class="btn btn--danger" @click="archive($event, localKpi)">{{ $t('btn.delete') }}</button>
-          <button class="btn btn--primary" :form="`kpi_${localKpi.id}`">
-            <i class="icon fa fa-fw fa-save" />
-            {{ $t('btn.saveChanges') }}
-          </button>
-        </div>
       </form>
     </validation-observer>
+
+    <div class="button-row">
+      <btn-delete :icon-only="true" @click="archive($event, localKpi)" />
+      <btn-save :form="`kpi_${localKpi.id}`" />
+    </div>
   </div>
 </template>
 
@@ -166,11 +163,14 @@ import IconArrowCircle from '@/assets/IconArrowCircle.vue';
 import { kpiFormats, kpiTypes } from '@/util/kpiHelpers';
 import Kpi from '@/db/Kpi';
 import { toastArchiveAndRevert } from '@/util';
+import { BtnSave, BtnDelete } from '@/components/generic/form/buttons';
 
 export default {
   name: 'ItemAdminKPI',
 
   components: {
+    BtnSave,
+    BtnDelete,
     IconArrowCircle,
   },
 
@@ -310,25 +310,6 @@ export default {
   padding: 0.5rem;
   background: var(--color-red);
   border-radius: 2px;
-}
-
-.btn--primary {
-  color: var(--color-text);
-  background: var(--color-green);
-}
-
-.btn--danger {
-  color: var(--color-text);
-  background: transparent;
-}
-
-.icon {
-  padding-right: 0.3rem;
-}
-
-.button-row {
-  display: flex;
-  justify-content: flex-end;
 }
 
 .button-sync-row {

--- a/src/views/ItemAdmin/ItemAdminKeyResult.vue
+++ b/src/views/ItemAdmin/ItemAdminKeyResult.vue
@@ -171,14 +171,12 @@
     </label>
 
     <div class="button-row">
-      <button v-if="!keyResult.archived" class="btn btn--icon btn--archive" :disabled="loading" @click="archive">
-        <i class="icon fa fa-fw fa-trash" />
-        {{ $t('btn.delete') }}
-      </button>
-      <button class="btn btn--icon btn--pri btn--icon-pri" form="update-keyResult" :disabled="loading">
-        <i class="icon fa fa-fw fa-save" />
-        {{ $t('btn.saveChanges') }}
-      </button>
+      <btn-delete
+        v-if="!keyResult.archived"
+        :disabled="loading"
+        @click="archive"
+      />
+      <btn-save form="update-keyResult" :disabled="loading" />
     </div>
   </div>
 </template>
@@ -187,13 +185,17 @@
 import { db, functions } from '@/config/firebaseConfig';
 import KeyResult from '@/db/KeyResult';
 import { toastArchiveAndRevert } from '@/util';
+import { BtnSave, BtnDelete } from '@/components/generic/form/buttons';
 
 export default {
   name: 'ItemAdminKeyResult',
 
   components: {
     ArchivedRestore: () => import('@/components/ArchivedRestore.vue'),
-    ContentLoaderOkrDetails: () => import('@/components/ContentLoader/ContentLoaderItemAdminOKRDetails.vue'),
+    ContentLoaderOkrDetails: () =>
+      import('@/components/ContentLoader/ContentLoaderItemAdminOKRDetails.vue'),
+    BtnSave,
+    BtnDelete,
   },
   props: {
     data: {
@@ -389,21 +391,6 @@ export default {
   @media screen and (min-width: bp(xl)) {
     width: span(3, 0, span(10));
     margin-left: span(1, 2, span(10));
-  }
-
-  .btn--pri {
-    color: var(--color-text);
-    background: var(--color-green);
-  }
-
-  .btn--archive {
-    color: var(--color-text);
-    background: transparent;
-  }
-
-  .button-row {
-    display: flex;
-    justify-content: flex-end;
   }
 }
 </style>

--- a/src/views/ItemAdmin/ItemAdminObjective.vue
+++ b/src/views/ItemAdmin/ItemAdminObjective.vue
@@ -73,21 +73,12 @@
     </validation-observer>
 
     <div class="button-row">
-      <button
+      <btn-delete
         v-if="!objective.archived"
-        class="btn btn--icon btn--archive"
         :disabled="loading"
         @click="archive"
-      >
-        <span class="icon fa fa-fw fa-trash"></span> {{ $t('btn.delete') }}
-      </button>
-      <button
-        class="btn btn--icon btn--pri btn--icon-pri"
-        form="update-objective"
-        :disabled="loading"
-      >
-        <span class="icon fa fa-fw fa-save"></span> {{ $t('btn.saveChanges') }}
-      </button>
+      />
+      <btn-save form="update-objective" :disabled="loading" />
     </div>
   </div>
 </template>
@@ -97,6 +88,7 @@ import { db } from '@/config/firebaseConfig';
 import Objective from '@/db/Objective';
 import icons from '@/config/icons';
 import { toastArchiveAndRevert } from '@/util';
+import { BtnSave, BtnDelete } from '@/components/generic/form/buttons';
 
 export default {
   name: 'ItemAdminObjective',
@@ -105,6 +97,8 @@ export default {
     ArchivedRestore: () => import('@/components/ArchivedRestore.vue'),
     ContentLoaderOkrDetails: () =>
       import('@/components/ContentLoader/ContentLoaderItemAdminOKRDetails.vue'),
+    BtnSave,
+    BtnDelete,
   },
 
   props: {
@@ -230,21 +224,6 @@ export default {
   @media screen and (min-width: bp(xl)) {
     width: span(3, 0, span(10));
     margin-left: span(1, 2, span(10));
-  }
-
-  .btn--pri {
-    color: var(--color-text);
-    background: var(--color-green);
-  }
-
-  .btn--archive {
-    color: var(--color-text);
-    background: transparent;
-  }
-
-  .button-row {
-    display: flex;
-    justify-content: flex-end;
   }
 }
 </style>

--- a/src/views/ItemAdmin/ItemAdminPeriod.vue
+++ b/src/views/ItemAdmin/ItemAdminPeriod.vue
@@ -32,19 +32,16 @@
     </validation-observer>
 
     <div class="button-row">
-      <button v-if="!activePeriod.archived" class="btn btn--icon btn--archive" :disabled="loading" @click="archive">
-        <i class="icon fa fa-fw fa-trash" />
-        {{ $t('btn.delete') }}
-      </button>
-      <button
-        class="btn btn--icon btn--pri btn--icon-pri"
+      <btn-delete
+        v-if="!activePeriod.archived"
+        :disabled="loading"
+        @click="archive"
+      />
+      <btn-save
         form="update-period"
         data-cy="save_period"
         :disabled="loading"
-      >
-        <i class="icon fa fa-fw fa-save" />
-        {{ $t('btn.saveChanges') }}
-      </button>
+      />
     </div>
   </div>
 </template>
@@ -55,13 +52,17 @@ import endOfDay from 'date-fns/endOfDay';
 import format from 'date-fns/format';
 import Period from '@/db/Period';
 import { toastArchiveAndRevert } from '@/util';
+import { BtnSave, BtnDelete } from '@/components/generic/form/buttons';
 
 export default {
   name: 'ItemAdminPeriod',
 
   components: {
     ArchivedRestore: () => import('@/components/ArchivedRestore.vue'),
-    ContentLoaderOkrDetails: () => import('@/components/ContentLoader/ContentLoaderItemAdminOKRDetails.vue'),
+    ContentLoaderOkrDetails: () =>
+      import('@/components/ContentLoader/ContentLoaderItemAdminOKRDetails.vue'),
+    BtnSave,
+    BtnDelete,
   },
 
   props: {
@@ -183,21 +184,6 @@ export default {
   @media screen and (min-width: bp(xl)) {
     width: span(3, 0, span(10));
     margin-left: span(1, 2, span(10));
-  }
-
-  .btn--pri {
-    color: var(--color-text);
-    background: var(--color-green);
-  }
-
-  .btn--archive {
-    color: var(--color-text);
-    background: transparent;
-  }
-
-  .button-row {
-    display: flex;
-    justify-content: flex-end;
   }
 }
 </style>

--- a/src/views/KeyResultHome.vue
+++ b/src/views/KeyResultHome.vue
@@ -107,14 +107,13 @@
               </validation-observer>
             </div>
 
-            <button
+            <btn-save
               v-if="allowedToEditPeriod"
               form="modal"
+              variant="primary"
+              class="key-result__value--button"
               :disabled="isSaving"
-              class="btn btn--ods key-result__value--button"
-            >
-              {{ $t('btn.save') }}
-            </button>
+            />
           </div>
 
           <div class="key-result__graph">
@@ -170,6 +169,7 @@ import { getKeyResultProgressDetails } from '@/util/keyResultProgress';
 import routerGuard from '@/router/router-guards/keyResultHome';
 import WidgetProgressHistory from '@/components/widgets/WidgetProgressHistory/WidgetProgressHistory.vue';
 import WidgetsKeyResultMobile from '@/components/widgets/WidgetsKeyResultMobile.vue';
+import { BtnSave } from '@/components/generic/form/buttons';
 
 export default {
   name: 'KeyResultHome',
@@ -181,6 +181,7 @@ export default {
     ProgressBar: () => import('@/components/ProgressBar.vue'),
     WidgetProgressHistory,
     WidgetsKeyResultMobile,
+    BtnSave,
   },
 
   beforeRouteUpdate: routerGuard,
@@ -478,5 +479,6 @@ export default {
 
 .key-result__value--button {
   align-self: end;
+  border: 1px solid var(--color-white);
 }
 </style>


### PR DESCRIPTION
A lot of files changed, but mostly repeated edits except the components themselves 😉 

* Add some basic, reusable button components
* Align style and interaction for (all) form buttons, e.g. a confirm popover for all delete buttons

<img width="340" alt="bilde" src="https://user-images.githubusercontent.com/2866225/199038801-428a4dd7-71aa-4111-9a0a-17ddced639a0.png">
