### PR TITLE
Fix Norwegian spelling of dashboard

### DIFF
--- a/src/locale/locales/nb-NO.json
+++ b/src/locale/locales/nb-NO.json
@@ -141,7 +141,7 @@
     "resultIndicator": "Resultatindikator",
     "departmentObjectives": "Områdets mål",
     "departmentAbout": "Om produktområdet",
-    "dashboardEntry": "Se dashboard",
+    "dashboardEntry": "Se dashbord",
     "keyFigures": "KPI-er",
     "value": "Verdi",
     "target": "Målsetting"


### PR DESCRIPTION
Use the Norwegian spelling of dashboard, "dashbord", in the Norwegian translation.