### PR TITLE
Fix overflow in modals

### DIFF
--- a/src/components/modals/EditGoalsModal.vue
+++ b/src/components/modals/EditGoalsModal.vue
@@ -235,6 +235,10 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+::v-deep .modal {
+  overflow-y: visible;
+}
+
 .goal-form {
   display: flex;
   flex-direction: column;

--- a/src/styles/_modal.scss
+++ b/src/styles/_modal.scss
@@ -24,6 +24,7 @@
   max-height: 100%;
   padding: 2rem 1.5rem;
   background: var(--color-white);
+  overflow-y: auto;
   box-shadow: 0 5px 30px -10px rgba(black, 0.2);
 
   scrollbar-width: none; /* Hide scrollbar styles Firefox */


### PR DESCRIPTION
Long modals would overflow because of a change in
f2bc5fe80dae122c3b4b9de3525b60e0551dbd6a. Revert that change, but let the goal modal overflow to prevent the date modal from being clipped.