### PR TITLE
Use fixed-point formatting for KPIs

### DIFF
--- a/src/util/kpiHelpers.js
+++ b/src/util/kpiHelpers.js
@@ -65,7 +65,7 @@ function valueFormatter (defaultSpecifier, compactSpecifier) {
  */
 function kpiFormatFunction (formatId) {
   return {
-    integer: valueFormatter(',', '.2s'),
+    integer: valueFormatter(',.2~f', '.2s'),
     percentage: valueFormatter('.2p'),
   }[formatId];
 }


### PR DESCRIPTION
```
1.1 => 1,1
1.19 => 1,19
1.9 => 1,9
1.9999 => 2
1.989 => 1,99
1.9899 => 1,99
1.333 => 1,33
1.337 => 1,34
1.989999999 => 1,99
123 => 123
123456 => 123 456
1234561231 => 1 234 561 231
1999999 => 1 999 999
123456.33333 => 123 456,33
123456.99999 => 123 457
27.9204761905 => 27,92
27.9294761905 => 27,93
```