### PR TITLE
Avoid double chart rendering

### DIFF
--- a/src/components/DashboardResultIndicatorsSection.vue
+++ b/src/components/DashboardResultIndicatorsSection.vue
@@ -269,10 +269,6 @@ export default {
       this.setActiveTab(0);
     },
 
-    goals() {
-      this.renderGraph();
-    },
-
     theme() {
       this.renderGraph();
     },


### PR DESCRIPTION
Revert a part of 787e7b4a7ca0033e75b7a088a1efd1c881118092 causing line charts to be rendered twice, which results in losing the transition animation between graphs.