### PR TITLE
Add status endpoint to API for KPI monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ Firebase now exports storage emulator as well, even if you don't use it. These n
 
 It is possible to set up open API end points for users outside of the OKR-tracker frontend to update progress of Key Results and KPI's. To do so, you only need to deploy all the functions as usual, and then give the users the Cloud Function URL, but we do not recommend to call the Cloud Function directly. The better approach would be to set up a Google Cloud API Gateway and then reroute all the calls to the right Cloud Function.
 
-We have set up an Open API specification which you can check out [here](./public/openapi/v1.2.0.yaml).
+We have set up an Open API specification which you can check out [here](./public/openapi/v1.3.0.yaml).
 
 You can read more about on how to set up an API Gateway [here](https://cloud.google.com/api-gateway/docs/quickstart).
 

--- a/functions/api/helpers.js
+++ b/functions/api/helpers.js
@@ -136,15 +136,13 @@ export async function buildKpiResponse(kpiSnapshot) {
       return { value, timestamp: timestamp.toDate() };
     });
 
-  const isStale = isKPIStale(updateFrequency, latestMeasurement);
-
   return {
     currentValue,
     name,
     type,
     lastUpdated: latestMeasurement || null,
     updateFrequency: updateFrequency || null,
-    isStale,
+    isStale: isKPIStale(updateFrequency, latestMeasurement),
     created: created ? created.toDate() : null,
     createdBy: createdBy ? await getUserDisplayName(createdBy) : null,
     edited: edited ? edited.toDate() : null,

--- a/functions/api/helpers.js
+++ b/functions/api/helpers.js
@@ -136,7 +136,7 @@ export async function buildKpiResponse(kpiSnapshot) {
       return { value, timestamp: timestamp.toDate() };
     });
 
-  const isStale = determineKPIStaleState(updateFrequency, latestMeasurement);
+  const isStale = isKPIStale(updateFrequency, latestMeasurement);
 
   return {
     currentValue,
@@ -154,12 +154,13 @@ export async function buildKpiResponse(kpiSnapshot) {
 
 /**
  * Return true if a KPI is considered "stale", i.e. no progress measurement
- * registered within declared update frequency.
+ * registered within declared update frequency. Return `null` in cases where
+ * it is not possible to determine staleness.
  *
  * `updateFrequency` is the expected update interval for the KPI.
  * `progressRecord` is the progress record to check against.
  */
-function determineKPIStaleState(updateFrequency, progressRecord) {
+function isKPIStale(updateFrequency, progressRecord) {
   if (!updateFrequency) return null;
   if (!progressRecord) return true;
   if (updateFrequency === 'irregular') return false;

--- a/functions/api/helpers.js
+++ b/functions/api/helpers.js
@@ -109,50 +109,47 @@ export async function refreshKPILatestValue(kpiRef) {
 }
 
 /**
- * Get list of KPIs including latest progress measurement.
+ * Build and return KPI response object.
+ *
+ * `kpiSnapshot` is the Firestore KPI document snapshot.
  */
-export async function getKPIs() {
-  const db = getFirestore();
+export async function buildKpiResponse(kpiSnapshot) {
+  const {
+    created,
+    createdBy,
+    currentValue,
+    edited,
+    editedBy,
+    name,
+    type,
+    updateFrequency,
+  } = kpiSnapshot.data();
 
-  const kpisSnapshot = await db
-    .collection('kpis')
-    .where('archived', '==', false)
-    .get();
-
-  const kpis = [];
-
-  for await (const kpiSnapshot of kpisSnapshot.docs) {
-    const { name, parent, valid, updateFrequency } = kpiSnapshot.data();
-
-    const parentName = await parent
-      .get()
-      .then((snapshot) => (snapshot.exists ? snapshot.data().name : null));
-
-    const latestMeasurement = await db
-      .collection(`kpis/${kpiSnapshot.id}/progress`)
-      .orderBy('timestamp', 'desc')
-      .limit(1)
-      .get()
-      .then((snapshot) => {
-        if (!snapshot.docs[0]) return null;
-        const { value, timestamp } = snapshot.docs[0].data();
-        return { value, timestamp: timestamp.toDate() };
-      });
-
-    const isStale = determineKPIStaleState(updateFrequency, latestMeasurement);
-
-    kpis.push({
-      id: kpiSnapshot.id,
-      name,
-      parentName,
-      valid,
-      latestMeasurement,
-      updateFrequency: updateFrequency || null,
-      isStale,
+  const latestMeasurement = await kpiSnapshot.ref
+    .collection('progress')
+    .orderBy('timestamp', 'desc')
+    .limit(1)
+    .get()
+    .then((snapshot) => {
+      if (!snapshot.docs[0]) return null;
+      const { value, timestamp } = snapshot.docs[0].data();
+      return { value, timestamp: timestamp.toDate() };
     });
-  }
 
-  return kpis;
+  const isStale = determineKPIStaleState(updateFrequency, latestMeasurement);
+
+  return {
+    currentValue,
+    name,
+    type,
+    lastUpdated: latestMeasurement || null,
+    updateFrequency: updateFrequency || null,
+    isStale,
+    created: created ? created.toDate() : null,
+    createdBy: createdBy ? await getUserDisplayName(createdBy) : null,
+    edited: edited ? edited.toDate() : null,
+    editedBy: editedBy ? await getUserDisplayName(editedBy) : null,
+  };
 }
 
 /**

--- a/functions/api/helpers.js
+++ b/functions/api/helpers.js
@@ -5,7 +5,6 @@ import {
   setHours,
   isWithinInterval,
   sub,
-  set,
 } from 'date-fns';
 
 /**
@@ -182,14 +181,9 @@ function isKPIStale(updateFrequency, progressRecord) {
 
   try {
     const now = new Date();
-    const intervalEnd = set(progressRecord.timestamp, {
-      year: now.getFullYear(),
-      month: now.getMonth(),
-      date: now.getDate(),
-    });
     return !isWithinInterval(progressRecord.timestamp, {
-      start: sub(intervalEnd, duration(updateFrequency)),
-      end: intervalEnd,
+      start: sub(startOfDay(now), duration(updateFrequency)),
+      end: endOfDay(now),
     });
   } catch (e) {
     console.error('ERROR: ', e.message);

--- a/functions/api/index.js
+++ b/functions/api/index.js
@@ -10,6 +10,7 @@ import config from '../config.js';
 // Routes
 import kpiRoutes from './routes/kpi.js';
 import keyResRoutes from './routes/keyres.js';
+import statusRoutes from './routes/status.js';
 
 const app = express();
 
@@ -19,8 +20,8 @@ app.use(express.json());
 app.use(morgan('combined'));
 
 app.use('/kpi', kpiRoutes);
-
 app.use('/keyres', keyResRoutes);
+app.use('/status', statusRoutes);
 
 const api = functions.runWith(config.runtimeOpts).region(config.region).https.onRequest(app);
 

--- a/functions/api/routes/status.js
+++ b/functions/api/routes/status.js
@@ -1,34 +1,38 @@
 import express from 'express';
-import { getKPIs } from '../helpers.js';
+import { getFirestore } from 'firebase-admin/firestore';
+import { buildKpiResponse } from '../helpers.js';
 
 const router = express.Router();
 
 router.get('/', async (req, res) => {
-  try {
-    const kpis = await getKPIs();
-    res.json({
-      kpis: {
-        total: kpis.length,
-        state: {
-          stale: kpis.filter((kpi) => kpi.isStale).length,
-          unknown: kpis.filter((kpi) => kpi.isStale === null).length,
-        },
-      },
-    });
-  } catch (e) {
-    console.error('ERROR: ', e.message);
-    res.status(500).send('Could not get list of KPIs');
-  }
-});
+  const db = getFirestore();
+  const kpis = [];
 
-router.get('/kpis', async (req, res) => {
   try {
-    const kpis = await getKPIs();
-    res.json(kpis);
+    const kpiQuerySnapshot = await db
+      .collection('kpis')
+      .where('archived', '==', false)
+      .get();
+
+    for await (const kpiSnapshot of kpiQuerySnapshot.docs) {
+      const kpiData = await buildKpiResponse(kpiSnapshot);
+      kpis.push(kpiData);
+    }
   } catch (e) {
     console.error('ERROR: ', e.message);
     res.status(500).send('Could not get list of KPIs');
+    return;
   }
+
+  res.json({
+    kpis: {
+      total: kpis.length,
+      state: {
+        stale: kpis.filter((kpi) => kpi.isStale).length,
+        unknown: kpis.filter((kpi) => kpi.isStale === null).length,
+      },
+    },
+  });
 });
 
 export default router;

--- a/functions/api/routes/status.js
+++ b/functions/api/routes/status.js
@@ -1,0 +1,34 @@
+import express from 'express';
+import { getKPIs } from '../helpers.js';
+
+const router = express.Router();
+
+router.get('/', async (req, res) => {
+  try {
+    const kpis = await getKPIs();
+    res.json({
+      kpis: {
+        total: kpis.length,
+        state: {
+          stale: kpis.filter((kpi) => kpi.isStale).length,
+          unknown: kpis.filter((kpi) => kpi.isStale === null).length,
+        },
+      },
+    });
+  } catch (e) {
+    console.error('ERROR: ', e.message);
+    res.status(500).send('Could not get list of KPIs');
+  }
+});
+
+router.get('/kpis', async (req, res) => {
+  try {
+    const kpis = await getKPIs();
+    res.json(kpis);
+  } catch (e) {
+    console.error('ERROR: ', e.message);
+    res.status(500).send('Could not get list of KPIs');
+  }
+});
+
+export default router;

--- a/public/openapi/v1.3.0.yaml
+++ b/public/openapi/v1.3.0.yaml
@@ -1,0 +1,369 @@
+swagger: "2.0"
+
+info:
+  title: OKR Tracker API
+  description: API for updating KPIs and key results.
+  version: 1.3.0
+  contact:
+    name: Dataspeilet
+    url: https://okr.oslo.systems
+    email: annemerete.pettersen@origo.oslo.kommune.no
+  license:
+    name: MIT
+    url: https://opensource.org/licenses/MIT
+schemes:
+  - https
+produces:
+  - application/json
+x-google-backend:
+  address: https://<location>-<project-id>.cloudfunctions.net/<CF-location>
+  path_translation: APPEND_PATH_TO_ADDRESS
+  protocol: h2
+security:
+  - api_key: []
+
+paths:
+  /kpi:
+    get:
+      summary: Get KPIs.
+      operationId: getKPI
+      responses:
+        200:
+          description: A successful response
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Kpi'
+        500:
+          $ref: '#/responses/Unavailable'
+  /kpi/{id}:
+    get:
+      summary: Get KPI.
+      operationId: getKPI
+      parameters:
+        - name: id
+          in: path
+          description: KPI Id
+          required: true
+          type: string
+      responses:
+        200:
+          description: A successful response
+          schema:
+            $ref: '#/definitions/Kpi'
+        404:
+          $ref: '#/responses/NotFound'
+        500:
+          $ref: '#/responses/Unavailable'
+    post:
+      summary: Post KPI progression.
+      operationId: postKPI
+      security:
+        - api_key: []
+      parameters:
+        - name: id
+          in: path
+          description: KPI Id
+          required: true
+          type: string
+        - name: progress
+          in: body
+          required: true
+          description: updated progress
+          schema:
+            type: number
+            example:
+              progress: 123
+        - name: okr-team-secret
+          in: header
+          description: Identify yourself with the secret you chose in your Team's settings
+          type: string
+      responses:
+        '200':
+          description: A successful response
+          schema:
+            type: string
+            example: "Updated KPI (${id}) with progress: ${progress}"
+        400:
+          $ref: '#/responses/BadRequest'
+        404:
+          $ref: '#/responses/NotFound'
+        500:
+          $ref: '#/responses/Unavailable'
+  /kpi/{id}/values:
+    get:
+      summary: Get KPI progression history.
+      operationId: getKPIProgressionValues
+      parameters:
+        - name: id
+          in: path
+          description: KPI Id
+          required: true
+          type: string
+      responses:
+        200:
+          description: A successful response
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/KpiMeasurement'
+        404:
+          $ref: '#/responses/NotFound'
+        500:
+          $ref: '#/responses/Unavailable'
+  /kpi/{id}/values/{date}:
+    parameters:
+      - name: id
+        in: path
+        description: KPI Id
+        required: true
+        type: string
+      - name: date
+        in: path
+        description: Date
+        required: true
+        type: string
+        format: date
+      - name: okr-team-secret
+        in: header
+        description: Identify yourself with the secret you chose in your Team's settings
+        type: string
+    put:
+      summary: Create or update KPI progression value.
+      operationId: updateKPIProgressionValue
+      parameters:
+        - name: value
+          in: body
+          required: true
+          description: Progression value
+          schema:
+            type: number
+            example:
+              value: 123
+      responses:
+        200:
+          description: A successful response
+          schema:
+            type: object
+            properties:
+              message:
+                type: string
+        400:
+          $ref: '#/responses/BadRequest'
+        404:
+          $ref: '#/responses/NotFound'
+        500:
+          $ref: '#/responses/Unavailable'
+    delete:
+      summary: Delete KPI progression value.
+      operationId: deleteKPIProgressionValue
+      responses:
+        200:
+          description: A successful response
+          schema:
+            type: object
+            properties:
+              message:
+                type: string
+        400:
+          $ref: '#/responses/BadRequest'
+        404:
+          $ref: '#/responses/NotFound'
+        500:
+          $ref: '#/responses/Unavailable'
+  /keyres/{id}:
+    get:
+      summary: Get key result.
+      operationId: getKeyRes
+      security:
+        - api_key: []
+      parameters:
+        - name: id
+          in: path
+          description: Key result Id
+          required: true
+          type: string
+      responses:
+        '200':
+          description: A successful response
+          schema:
+            $ref: '#/definitions/Keyres'
+        404:
+          $ref: '#/responses/NotFound'
+        500:
+          $ref: '#/responses/Unavailable'
+    post:
+      summary: Post key result progression.
+      operationId: postKeyRes
+      security:
+        - api_key: []
+      parameters:
+        - name: id
+          in: path
+          description: Key res Id
+          required: true
+          type: string
+        - name: progress
+          in: body
+          required: true
+          description: updated progress
+          schema:
+            type: number
+            example:
+              progress: 123
+        - name: okr-team-secret
+          in: header
+          description: Identify yourself with the secret you chose in your Team's settings
+          type: string
+      responses:
+        '200':
+          description: A successful response
+          schema:
+            type: string
+            example: "Updated Key result (${id}) with progress: ${progress}"
+        400:
+          $ref: '#/responses/BadRequest'
+        404:
+          $ref: '#/responses/NotFound'
+        500:
+          $ref: '#/responses/Unavailable'
+  /status:
+    get:
+      summary: Get OKR Tracker metrics.
+      operationId: getStatus
+      responses:
+        200:
+          description: A successful response
+          schema:
+            $ref: '#/definitions/TrackerMetrics'
+        500:
+          $ref: '#/responses/Unavailable'
+
+securityDefinitions:
+  api_key:
+    type: "apiKey"
+    name: "x-api-key"
+    in: "header"
+
+definitions:
+  Keyres:
+    properties:
+      currentValue:
+        type: number
+      progression:
+        type: number
+      description:
+        type: string
+      created:
+        type: string
+        format: date-time
+      edited:
+        type: string
+        format: date-time
+      createdBy:
+        type: string
+      editedBy:
+        type: string
+      lastUpdated:
+        type: object
+        properties:
+          value:
+            type: number
+          timestamp:
+            type: string
+            format: date-time
+          comment:
+            type: string
+          createdBy:
+            type: string
+  Kpi:
+    properties:
+      currentValue:
+        type: number
+      name:
+        type: string
+      type:
+        type: string
+      created:
+        type: string
+        format: date-time
+      edited:
+        type: string
+        format: date-time
+      createdBy:
+        type: string
+      editedBy:
+        type: string
+      lastUpdated:
+        type: object
+        properties:
+          value:
+            type: number
+          timestamp:
+            type: string
+            format: date-time
+      updateFrequency:
+        type: string
+        enum: [daily, weekly, monthly, quarterly, annual, irregular]
+      isStale:
+        type: boolean
+        example: false
+  KpiMeasurement:
+    type: object
+    properties:
+      value:
+        type: number
+      date:
+        type: string
+        format: date
+      comment:
+        type: string
+      created:
+        type: string
+        format: date-time
+      createdBy:
+        type: string
+      edited:
+        type: string
+        format: date-time
+      editedBy:
+        type: string
+  TrackerMetrics:
+    properties:
+      kpis:
+        type: object
+        properties:
+          total:
+            type: integer
+          state:
+            type: object
+            properties:
+              stale:
+                type: integer
+              unknown:
+                type: integer
+
+responses:
+  NotFound:
+    description: Resource not found
+    schema:
+      type: object
+      properties:
+        message:
+          type: string
+  Unavailable:
+    description: Something went wrong
+    schema:
+      type: object
+      properties:
+        message:
+          type: string
+  BadRequest:
+    description: A bad request
+    schema:
+      type: object
+      properties:
+        errors:
+          type: object
+        message:
+          type: string

--- a/src/views/Api.vue
+++ b/src/views/Api.vue
@@ -15,7 +15,7 @@ export default {
 
   mounted() {
     SwaggerUi({
-      url: './openapi/v1.2.0.yaml',
+      url: './openapi/v1.3.0.yaml',
       dom_id: '#swagger-ui',
     });
   },


### PR DESCRIPTION
Adds the following new API endpoints:
* `GET /kpi` - list all KPIs, with a couple of additional properties (`updateFrequency`, `isStale`)
* `GET /stats`- return some app "metrics", for now different KPI counts