### PR TITLE
Switch default branch to `main`

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,9 +2,9 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ develop ]
+    branches: [ main ]
   pull_request:
-    branches: [ develop ]
+    branches: [ main ]
   schedule:
     - cron: '0 7 * * 1'
   workflow_dispatch:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,13 +2,13 @@
 
 name: CI
 
-# Controls when the action will run. Triggers the workflow on push or pull request
-# events but only for the master branch
+# Controls when the action will run. Triggers the workflow on push and pull
+# requests to the `main` branch.
 on:
   push:
-    branches: [develop]
+    branches: [main]
   pull_request:
-    branches: [develop]
+    branches: [main]
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/contributing.md
+++ b/contributing.md
@@ -2,7 +2,7 @@
 
 ## Bug reports
 
-Keep bug reports short but descriptive. Include all details that are relevant and what the exepected outcome should be.
+Keep bug reports short but descriptive. Include all details that are relevant and what the expected outcome should be.
 
 Example:
 
@@ -23,11 +23,11 @@ Example:
 Contributions to this repository are welcomed. Please ensure your pull requests adhere to the following guidelines:
 
 - Make individual pull requests for each of your suggested changes.
-- Code (including comments) and documentation should be in English. Check spelling and grammar
-- Make sure you lint your code before commiting.
+- Code (including comments) and documentation should be in English. Check spelling and grammar.
+- Make sure you lint your code before committing.
 - Add an entry in CHANGELOG.md describing your changes.
-- Merge the `develop` branch into your branch before opening a pull request.
-- Include a clear title and description
+- Rebase your branch on `main` or merge the `main` branch into your branch before opening a pull request.
+- Include a clear title and description.
 
 ## Feature requests
 


### PR DESCRIPTION
The `develop` and `master` branches are obsoleted in favor of a single `main` branch.