### PR TITLE
Speed up KPI progress plots

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -3,6 +3,7 @@
 import { initializeApp, cert } from 'firebase-admin/app';
 import functions from 'firebase-functions';
 import okrTrackerSlackBot from './slackbot/index.js';
+import handleKpiProgress from './kpi/progress/index.js';
 
 import { slackNotificationOnUserRequest, slackNotificationInteractiveOnRequest } from './requestAccess/index.js';
 import api from './api/index.js';
@@ -31,6 +32,7 @@ export { triggerScheduledFunction } from './automatedKeyResults.js';
 export { fetchKpiDataOnUpdate } from './kpi/index.js';
 export { fetchKpiDataOnCreate } from './kpi/index.js';
 export { fetchKpiDataOnSchedule } from './kpi/index.js';
+export { handleKpiProgress };
 
 export { slugDepartment } from './slug/index.js';
 export { slugOrganization } from './slug/index.js';

--- a/functions/kpi/progress/handleKpiProgress.js
+++ b/functions/kpi/progress/handleKpiProgress.js
@@ -1,0 +1,42 @@
+import { getFirestore } from 'firebase-admin/firestore';
+
+/**
+ * Cache the KPI progression as a JSON blob on the KPI document.
+ */
+export default async function updateKpiProgress (change, { params }) {
+  const db = getFirestore();
+  const { kpiId } = params;
+
+  const kpiRef = db.doc(`kpis/${kpiId}`);
+  const kpi = await kpiRef.get();
+
+  if (!kpi.exists) {
+    return false;
+  }
+
+  const progressCollection = await kpiRef
+    .collection('progress')
+    .orderBy('timestamp', 'desc')
+    .get()
+    .then((snapshot) => snapshot.docs)
+    .then((docs) => docs.map((d) => d.data()));
+
+  /*
+   * Compress the progress into a JSON string. We consider a four digits decimal
+   * precision to be a reasonable trade off between space and necessary
+   * accuracy.
+   */
+  const progress = JSON.stringify(progressCollection.map((p) => [
+    p.timestamp.toDate().toISOString().slice(0, 10),
+    parseFloat(p.value.toPrecision(4)),
+    p.comment || "",
+  ]));
+
+  try {
+    await kpiRef.update({ progress });
+  } catch (error) {
+    console.log('Could not update KPI', kpiId);
+  }
+
+  return true;
+};

--- a/functions/kpi/progress/handleKpiProgress.js
+++ b/functions/kpi/progress/handleKpiProgress.js
@@ -28,7 +28,7 @@ export default async function updateKpiProgress (change, { params }) {
    */
   const progress = JSON.stringify(progressCollection.map((p) => [
     p.timestamp.toDate().toISOString().slice(0, 10),
-    parseFloat(p.value.toPrecision(4)),
+    parseFloat(p.value.toFixed(4)),
     p.comment || "",
   ]));
 

--- a/functions/kpi/progress/index.js
+++ b/functions/kpi/progress/index.js
@@ -1,0 +1,11 @@
+import functions from 'firebase-functions';
+import config from '../../config.js';
+import updateKpiProgress from './handleKpiProgress.js';
+
+const handleKpiProgress = functions
+  .runWith(config.runtimeOpts)
+  .region(config.region)
+  .firestore.document(`kpis/{kpiId}/progress/{progressId}`)
+  .onWrite(updateKpiProgress);
+
+export default handleKpiProgress;

--- a/src/components/DashboardResultIndicatorsSection.vue
+++ b/src/components/DashboardResultIndicatorsSection.vue
@@ -191,7 +191,7 @@ export default {
     ...mapState(['kpis', 'subKpis', 'theme']),
     ...mapGetters(['hasEditRights']),
     periodTrend(){
-      const sortedProgress = this.filteredProgress.sort((a, b) =>
+      const sortedProgress = this.filteredProgress.slice().sort((a, b) =>
         a.timestamp.toDate() > b.timestamp.toDate() ? 1 : -1
       );
       const firstProgressRecord = sortedProgress[0]?.value;

--- a/src/util/LineChart/index.js
+++ b/src/util/LineChart/index.js
@@ -153,9 +153,13 @@ export default class LineChart {
       toValue += spread * 0.1;
     }
 
-    startDate.setHours(0, 0, 0, 0);
-    endDate.setHours(0, 0, 0, 0);
-    this.x.domain([startDate, endDate]);
+    // To avoid destructively modifying the passed parameters.
+    const _startDate = new Date(startDate);
+    const _endDate = new Date(endDate);
+
+    _startDate.setHours(0, 0, 0, 0);
+    _endDate.setHours(0, 0, 0, 0);
+    this.x.domain([_startDate, _endDate]);
     this.y.domain([fromValue, toValue]).nice();
 
     this.width = this.svg.node().getBoundingClientRect().width;
@@ -163,7 +167,7 @@ export default class LineChart {
 
     const innerWidth = this.width - CANVAS_PADDING.left - CANVAS_PADDING.right;
 
-    const mSecsBetween = endDate.getTime() - startDate.getTime();
+    const mSecsBetween = _endDate.getTime() - _startDate.getTime();
     const daysBetween = mSecsBetween / (1000 * 60 * 60 * 24);
 
     this.yAxis

--- a/src/views/KpiHome.vue
+++ b/src/views/KpiHome.vue
@@ -134,14 +134,8 @@ export default {
 
   watch: {
     activeKpi: {
-      immediate: true,
-      async handler({ id }) {
-        this.isLoading = true;
-        await this.$bind(
-          'progress',
-          db.collection(`kpis/${id}/progress`).orderBy('timestamp', 'desc')
-        );
-        this.isLoading = false;
+      async handler() {
+        this.setProgress();
       },
     },
     progress() {
@@ -159,11 +153,39 @@ export default {
       this.endDate = this.$route.query.endDate;
       this.range = `${this.startDate} til ${this.endDate}`;
     }
+
+    this.setProgress();
   },
 
   methods: {
     dateShort,
     formatKPIValue,
+
+    async setProgress() {
+      this.isLoading = true;
+
+      const { id, progress } = this.activeKpi;
+
+      if (progress) {
+        this.progress = JSON.parse(progress).map(m => {
+          return {
+            timestamp: {
+              toDate: () => new Date(m[0]),
+            },
+            value: m[1],
+          }
+        });
+
+        this.filterProgress();
+      } else {
+        await this.$bind(
+          'progress',
+          db.collection(`kpis/${id}/progress`).orderBy('timestamp', 'desc')
+        );
+      }
+
+      this.isLoading = false;
+    },
 
     async createProgressRecord(data, modalCloseHandler) {
       try {
@@ -205,7 +227,7 @@ export default {
         this.filteredProgress.map(({ value }) => value)
       );
       const [startDate, endDate] = extent(
-        this.filteredProgress.map(({ timestamp }) => timestamp)
+        this.filteredProgress.map(({ timestamp }) => timestamp.toDate())
       );
 
       if (!this.graph || startValue === undefined || targetValue === undefined)
@@ -213,8 +235,8 @@ export default {
       this.graph.render({
         startValue,
         targetValue,
-        startDate: startDate.toDate(),
-        endDate: this.isFiltered ? endDate.toDate() : new Date(),
+        startDate: startDate,
+        endDate: this.isFiltered ? endDate : new Date(),
         progress: this.filteredProgress,
         kpi: this.activeKpi,
       });


### PR DESCRIPTION
Speed up KPI progress plots by caching the progression as a JSON blob directly on the KPI Firestore document. Firestore isn't too happy about retrieving thousands of documents (like is typically needed from the `progression` sub collection).