### PR TITLE
Show right column even if there is no progression

### DIFF
--- a/src/components/widgets/WidgetsItemHomeRight.vue
+++ b/src/components/widgets/WidgetsItemHomeRight.vue
@@ -1,9 +1,10 @@
 <template>
-  <aside v-if="activeItem && progression">
+  <aside v-if="activeItem">
     <div class="widgets">
       <widget-dashboard-entry v-if="isDepartment(activeItem)" :slug="activeItem.slug" />
       <widget-admin-edit />
       <widget-wrapper
+        v-if="progression"
         :title="
           $t(
             `widget.progression.${


### PR DESCRIPTION
Hide only the progression wheel if there is no progression, not the entire right column.