### PR TITLE
Change emulator ports 5000 and 7777 that crash with MacOS Ventura

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -24,14 +24,14 @@
       "port": 8888
     },
     "hosting": {
-      "port": 5000
+      "port": 5002
     },
     "pubsub": {
       "port": 8085
     },
     "ui": {
       "enabled": true,
-      "port": "7777"
+      "port": "7778"
     },
     "auth": {
       "port": 9099


### PR DESCRIPTION
MacOS Ventura uses 5000 (!) for some Airplay server thing. And 7777 for 3rd party identity services.

How to test: Run `npm run dev` and check that the emulator starts.