### PR TITLE
Tweak KPI help text

### DIFF
--- a/src/locale/locales/en-US.json
+++ b/src/locale/locales/en-US.json
@@ -61,7 +61,7 @@
     "heading": "KPIs",
     "itemRowError": "error",
     "help": {
-      "updates": "KPIs can be updated manually through the OKR Tracker or automatically using an optional Google Sheets- or API-integration. Note that it is only possible to register a single value within a day. Read more about creating and updating KPIs {readMoreLink} (in Norwegian).",
+      "updates": "KPIs can be updated both manually through the OKR Tracker and automatically using a Google Sheets- or API-integration. Note that it is only possible to register a single value within a day. Read more about creating and updating KPIs {readMoreLink} (in Norwegian).",
       "readMoreHere": "here"
     },
     "automation": {

--- a/src/locale/locales/nb-NO.json
+++ b/src/locale/locales/nb-NO.json
@@ -61,7 +61,7 @@
     "heading": "KPI-er",
     "itemRowError": "feil",
     "help": {
-      "updates": "KPI-er kan oppdateres manuelt via OKR-trackeren eller automatisk ved bruk av en valgfri Google Sheets- eller API-integrasjon. Merk at det kun er mulig å retigstrere ett målepunkt per døgn. Les mer om opprettelse og oppdatering av KPI-er {readMoreLink}.",
+      "updates": "KPI-er kan både oppdateres manuelt via OKR-trackeren og automatisk via av en Google Sheets- eller API-integrasjon. Merk at det kun er mulig å registrere ett målepunkt per døgn. Les mer om opprettelse og oppdatering av KPI-er {readMoreLink}.",
       "readMoreHere": "her"
     },
     "automation": {


### PR DESCRIPTION
Tweak the KPI help text to make it clearer that manual and automatic updates aren't mutually exclusive. Also fix a typo in the Norwegian version.