### PR TITLE
Disable closing modals by outside click

### DIFF
--- a/src/components/modals/ModalWrapper.vue
+++ b/src/components/modals/ModalWrapper.vue
@@ -1,5 +1,5 @@
 <template>
-  <div ref="modalOverlay" class="overlay" @keydown.esc="close" @click.self="close">
+  <div ref="modalOverlay" class="overlay" @keydown.esc="close">
     <div :class="['modal', `modal--${variant}`]">
       <div class="modal__header">
         <h2 class="title-2">


### PR DESCRIPTION
Disable closing modals by clicking outside them. This to prevent accidental closing of modals that might contain unsaved changes in forms. It is still possible to close by using the escape key or the dedicated close button.