### PR TITLE
Revamp the progress API example

### DIFF
--- a/src/components/FormComponent.vue
+++ b/src/components/FormComponent.vue
@@ -40,7 +40,7 @@
           :readonly="readonly"
           :placeholder="placeholder"
           :class="fieldClass"
-          rows="4"
+          :rows="rows"
           :data-cy="dataCy"
         />
 
@@ -176,6 +176,11 @@ export default {
       required: false,
       default: '',
     },
+    rows: {
+      type: Number,
+      required: false,
+      default: 4,
+    },
   },
 
   data: () => ({
@@ -227,7 +232,7 @@ export default {
     copyFieldText(e) {
       e.preventDefault();
       const inputWrapperElement = e.currentTarget.parentElement;
-      const inputElement = inputWrapperElement.querySelector('input');
+      const inputElement = inputWrapperElement.querySelector(this.inputType);
       if (inputElement) {
         navigator.clipboard.writeText(inputElement.value).then(() => {
           this.$toasted.show(this.$t('toaster.action.copiedToClipboard'));

--- a/src/components/ProgressUpdateAPIExample.vue
+++ b/src/components/ProgressUpdateAPIExample.vue
@@ -1,0 +1,62 @@
+<template>
+  <form-component
+    input-type="textarea"
+    type="text"
+    :label="label"
+    :rows="5"
+    :readonly="true"
+    :copy-button="true"
+    :value="example"
+  >
+    <template #help>
+      <span v-if="help" class="form-help">{{ help }}</span>
+    </template>
+  </form-component>
+</template>
+
+<script>
+/**
+ * Component for displaying an example of how to use the progress update API.
+ */
+export default {
+  name: 'ProgressUpdateAPIExample',
+
+  props: {
+    path: {
+      type: String,
+      required: true,
+    },
+    label: {
+      type: String,
+      required: false,
+      default: '',
+    },
+    help: {
+      type: String,
+      required: false,
+      default: '',
+    },
+  },
+
+  computed: {
+    example() {
+      return [
+        'curl -X POST -H "okr-team-secret: <YOUR SECRET>"',
+        '-H "x-api-key: <YOUR API-KEY>"',
+        '-H "Content-Type: application/json"',
+        `-d '{ "progress": <VALUE> }'`,
+        `${import.meta.env.VITE_API_GATEWAY_URL}/${this.path}`,
+      ].join(' \\\n  ');
+    },
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+@use '@/styles/typography';
+
+::v-deep textarea {
+  margin: 0;
+  font-size: typography.$font-size-1;
+}
+</style>

--- a/src/components/forms/KpiAdminForm.vue
+++ b/src/components/forms/KpiAdminForm.vue
@@ -125,29 +125,6 @@
         />
       </toggle-button>
 
-      <toggle-button v-model="localKpi.api" name="api">
-        <template #label>
-          {{ $t('kpi.api.radio') }}
-          <i v-tooltip="$t('kpi.api.tooltip')" class="icon fa fa-info-circle" />
-        </template>
-
-        <div v-if="kpi">
-          <form-component
-            input-type="input"
-            type="text"
-            label="API"
-            rules="required"
-            :readonly="true"
-            :copy-button="true"
-            :value="apiCurl(kpi)"
-          >
-            <template #help>
-              <span class="form-help">{{ $t('kpi.api.help') }}</span>
-            </template>
-          </form-component>
-        </div>
-      </toggle-button>
-
       <hr class="ods-hr" />
 
       <form-component

--- a/src/components/forms/KpiAdminForm.vue
+++ b/src/components/forms/KpiAdminForm.vue
@@ -240,7 +240,6 @@ export default {
             sheetUrl: '',
             sheetName: '',
             sheetCell: '',
-            api: false,
             auto: false,
           };
         }
@@ -264,11 +263,6 @@ export default {
         throw new Error(error.message);
       }
     },
-
-    apiCurl: (kpi) =>
-      `curl -X POST -H "okr-team-secret: <YOUR SECRET>" -H "x-api-key: <YOUR API-KEY>" -H "Content-Type: application/json" -d '{ "progress": <VALUE> }' ${
-        import.meta.env.VITE_API_GATEWAY_URL
-      }/kpi/${kpi.id}`,
   },
 };
 </script>

--- a/src/components/modals/KPIProgressModal.vue
+++ b/src/components/modals/KPIProgressModal.vue
@@ -64,6 +64,18 @@
         />
       </template>
     </form-section>
+
+    <template #subfooter>
+      <hr class="ods-hr" />
+      <i18n path="kpi.help.apiProgress" tag="p">
+        <template #apiLink>
+          <router-link :to="{ name: 'Api' }" target="_blank">
+            <span>{{ $t('general.api') }}</span>
+          </router-link>
+        </template>
+      </i18n>
+      <ProgressUpdateAPIExample :path="`kpi/${activeKpi.id}`" />
+    </template>
   </modal-wrapper>
 </template>
 

--- a/src/components/modals/KPIProgressModal.vue
+++ b/src/components/modals/KPIProgressModal.vue
@@ -74,10 +74,16 @@ import { endOfDay } from 'date-fns';
 import Progress from '@/db/Kpi/Progress';
 import { dateShort } from '@/util';
 import { formatKPIValue } from '@/util/kpiHelpers';
+import ProgressUpdateAPIExample from '@/components/ProgressUpdateAPIExample.vue';
 import ProgressModal from './ProgressModal.vue';
 
 export default {
   name: 'KPIProgressModal',
+
+  components: {
+    ProgressUpdateAPIExample,
+  },
+
   extends: ProgressModal,
 
   data: () => ({

--- a/src/components/modals/KPIProgressModal.vue
+++ b/src/components/modals/KPIProgressModal.vue
@@ -74,7 +74,7 @@
           </router-link>
         </template>
       </i18n>
-      <ProgressUpdateAPIExample :path="`kpi/${activeKpi.id}`" />
+      <progress-update-API-example :path="`kpi/${activeKpi.id}`" />
     </template>
   </modal-wrapper>
 </template>

--- a/src/components/modals/ModalWrapper.vue
+++ b/src/components/modals/ModalWrapper.vue
@@ -17,6 +17,10 @@
       <div v-if="$slots.footer" class="modal__footer">
         <slot name="footer" />
       </div>
+
+      <div v-if="$slots.subfooter" class="modal__subfooter">
+        <slot name="subfooter" />
+      </div>
     </div>
   </div>
 </template>

--- a/src/components/modals/ProgressModal.vue
+++ b/src/components/modals/ProgressModal.vue
@@ -196,4 +196,8 @@ export default {
     top: 0;
   }
 }
+
+.help-text {
+  margin-top: 0.5rem;
+}
 </style>

--- a/src/locale/locales/en-US.json
+++ b/src/locale/locales/en-US.json
@@ -55,15 +55,12 @@
     "itemRowError": "error",
     "help": {
       "updates": "KPIs can be updated both manually through the OKR Tracker and automatically using a Google Sheets- or API-integration. Note that it is only possible to register a single value within a day. Read more about creating and updating KPIs {readMoreLink} (in Norwegian).",
-      "readMoreHere": "here"
+      "readMoreHere": "here",
+      "apiProgress": "New measurements can be registered with {apiLink} calls, for instance by using curl as shown below.",
+      "manualProgress": "New measurements can also be added manually by using the form below."
     },
     "automation": {
       "radio": "Fetch values automatically from a spreadsheet (Google Sheets)?"
-    },
-    "api": {
-      "radio": "Update values programmtically using the API?",
-      "help": "Push updates with curl",
-      "tooltip": "Toggle this if you have plans to update your KPI yourself via the OKR-tracker API"
     },
     "goals": {
       "goals": "Goals",

--- a/src/locale/locales/en-US.json
+++ b/src/locale/locales/en-US.json
@@ -56,8 +56,7 @@
     "help": {
       "updates": "KPIs can be updated both manually through the OKR Tracker and automatically using a Google Sheets- or API-integration. Note that it is only possible to register a single value within a day. Read more about creating and updating KPIs {readMoreLink} (in Norwegian).",
       "readMoreHere": "here",
-      "apiProgress": "New measurements can be registered with {apiLink} calls, for instance by using curl as shown below.",
-      "manualProgress": "New measurements can also be added manually by using the form below."
+      "apiProgress": "New measurements can be registered with {apiLink} calls, for instance by using curl as shown below."
     },
     "automation": {
       "radio": "Fetch values automatically from a spreadsheet (Google Sheets)?"

--- a/src/locale/locales/nb-NO.json
+++ b/src/locale/locales/nb-NO.json
@@ -56,8 +56,7 @@
     "help": {
       "updates": "KPI-er kan både oppdateres manuelt via OKR-trackeren og automatisk via av en Google Sheets- eller API-integrasjon. Merk at det kun er mulig å registrere ett målepunkt per døgn. Les mer om opprettelse og oppdatering av KPI-er {readMoreLink}.",
       "readMoreHere": "her",
-      "apiProgress": "Nye målepunkt kan registreres via {apiLink}-kall, for eksempel ved bruk av curl som vist nedenfor.",
-      "manualProgress": "Nye målepunkt kan også legges til manuelt ved å fylle ut skjemaet nedenfor."
+      "apiProgress": "Nye målepunkt kan også registreres via {apiLink}-kall, for eksempel ved bruk av curl som vist nedenfor."
     },
     "automation": {
       "radio": "Hente KPI-verdier automatisk fra et regneark (Google Sheets)?"

--- a/src/locale/locales/nb-NO.json
+++ b/src/locale/locales/nb-NO.json
@@ -55,15 +55,12 @@
     "itemRowError": "feil",
     "help": {
       "updates": "KPI-er kan både oppdateres manuelt via OKR-trackeren og automatisk via av en Google Sheets- eller API-integrasjon. Merk at det kun er mulig å registrere ett målepunkt per døgn. Les mer om opprettelse og oppdatering av KPI-er {readMoreLink}.",
-      "readMoreHere": "her"
+      "readMoreHere": "her",
+      "apiProgress": "Nye målepunkt kan registreres via {apiLink}-kall, for eksempel ved bruk av curl som vist nedenfor.",
+      "manualProgress": "Nye målepunkt kan også legges til manuelt ved å fylle ut skjemaet nedenfor."
     },
     "automation": {
       "radio": "Hente KPI-verdier automatisk fra et regneark (Google Sheets)?"
-    },
-    "api": {
-      "radio": "Oppdatere verdier programmatisk via API?",
-      "help": "Eksempel for hvordan KPI-en kan oppdateres ved bruk av curl",
-      "tooltip": "Skru på denne hvis du har planer om å oppdatere KPI-en selv via OKR-tracker sitt API. Du kan fortsatt oppdatere manuelt også."
     },
     "goals": {
       "goals": "Mål",

--- a/src/views/ItemAdmin/ItemAdminKeyResult.vue
+++ b/src/views/ItemAdmin/ItemAdminKeyResult.vue
@@ -119,7 +119,7 @@
             <i v-tooltip="$t('keyResult.api.tooltip')" class="icon fa fa-info-circle" />
           </template>
 
-          <ProgressUpdateAPIExample
+          <progress-update-API-example
             label="API"
             :help="$t('admin.curlHelp')"
             :path="`keyres/${keyResult.id}`"

--- a/src/views/ItemAdmin/ItemAdminKeyResult.vue
+++ b/src/views/ItemAdmin/ItemAdminKeyResult.vue
@@ -119,19 +119,11 @@
             <i v-tooltip="$t('keyResult.api.tooltip')" class="icon fa fa-info-circle" />
           </template>
 
-          <form-component
-            input-type="input"
-            type="text"
+          <ProgressUpdateAPIExample
             label="API"
-            rules="required"
-            :readonly="true"
-            :copy-button="true"
-            :value="apiCurl(keyResult)"
-          >
-            <template #help>
-              <span class="form-help">{{ $t('admin.curlHelp') }}</span>
-            </template>
-          </form-component>
+            :help="$t('admin.curlHelp')"
+            :path="`keyres/${keyResult.id}`"
+          />
         </toggle-button>
 
         <div v-if="keyResult.auto && keyResult.api" class="ok-alert ok-alert--warning">
@@ -154,6 +146,7 @@ import { toastArchiveAndRevert } from '@/util';
 import { BtnSave, BtnDelete } from '@/components/generic/form/buttons';
 import ToggleButton from '@/components/generic/form/ToggleButton.vue';
 import GoogleSheetsFormGroup from '@/components/forms/partials/GoogleSheetsFormGroup.vue';
+import ProgressUpdateAPIExample from '@/components/ProgressUpdateAPIExample.vue';
 
 export default {
   name: 'ItemAdminKeyResult',
@@ -166,6 +159,7 @@ export default {
     BtnDelete,
     ToggleButton,
     GoogleSheetsFormGroup,
+    ProgressUpdateAPIExample,
   },
   props: {
     data: {
@@ -329,11 +323,6 @@ export default {
       }
       return msg;
     },
-
-    apiCurl: (keyResult) =>
-      `curl -X POST -H "okr-team-secret: <YOUR SECRET>" -H "x-api-key: <YOUR API-KEY>" -H "Content-Type: application/json" -d '{ "progress": <VALUE> }'  ${
-        import.meta.env.VITE_API_GATEWAY_URL
-      }/keyres/${keyResult.id}`,
   },
 };
 </script>


### PR DESCRIPTION
Move the progress API example from the KPI creation page to the dialogue where progression values are registered. Also align it with the example for key result progression by generalizing the functionality into a component that can be used in both places.