### PR TITLE
Remove trigger on KPI updates

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -33,7 +33,6 @@ export { automatedRestore } from './backupAndRestore.js';
 export { fetchAutomatedKeyResOnSchedule } from './automatedKeyResults.js';
 export { triggerScheduledFunction } from './automatedKeyResults.js';
 
-export { fetchKpiDataOnUpdate } from './kpi/index.js';
 export { fetchKpiDataOnCreate } from './kpi/index.js';
 export { fetchKpiDataOnSchedule } from './kpi/index.js';
 export { handleKpiProgress };

--- a/functions/kpi/index.js
+++ b/functions/kpi/index.js
@@ -10,12 +10,6 @@ export const fetchKpiDataOnCreate = functions
   .firestore.document(`kpis/{documentId}`)
   .onCreate(fetchKpiData);
 
-export const fetchKpiDataOnUpdate = functions
-  .runWith(config.runtimeOpts)
-  .region(config.region)
-  .firestore.document(`kpis/{documentId}`)
-  .onUpdate(({ after }) => fetchKpiData(after));
-
 export const fetchKpiDataOnSchedule = functions
   .runWith(config.runtimeOpts)
   .region(config.region)

--- a/src/views/ItemAdmin/ItemAdminKPI.vue
+++ b/src/views/ItemAdmin/ItemAdminKPI.vue
@@ -161,8 +161,6 @@ export default {
 
     async save(kpi) {
       this.loading = true;
-      kpi.error = false;
-      kpi.valid = false;
       delete kpi.parent;
 
       try {


### PR DESCRIPTION
Remove the function that triggered on KPI updates due to an infinite loop with our progress updating function.

This is intended as an emergency fix. It caused the Google Sheet integration checking for KPIs to disappear when KPIs are saved, but that will be fixed later (for instance by adding a separate button for checking the connection, like we have for key results).