### PR TITLE
Restore Google Sheets testing functionality

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -35,6 +35,7 @@ export { triggerScheduledFunction } from './automatedKeyResults.js';
 
 export { fetchKpiDataOnCreate } from './kpi/index.js';
 export { fetchKpiDataOnSchedule } from './kpi/index.js';
+export { fetchKpiDataTrigger } from './kpi/index.js';
 export { handleKpiProgress };
 export { handleKpiGoals };
 

--- a/functions/kpi/index.js
+++ b/functions/kpi/index.js
@@ -26,3 +26,17 @@ export const fetchKpiDataOnSchedule = functions
         throw new Error(e);
       });
   });
+
+export const fetchKpiDataTrigger = functions
+  .runWith(config.runtimeOpts)
+  .region(config.region)
+  .https.onCall((id) => {
+    return getFirestore()
+      .collection('kpis')
+      .doc(id)
+      .get()
+      .then(fetchKpiData)
+      .catch((e) => {
+        throw new Error(e);
+      });
+  });

--- a/src/components/forms/KpiAdminForm.vue
+++ b/src/components/forms/KpiAdminForm.vue
@@ -177,6 +177,7 @@
 </template>
 
 <script>
+import { functions } from '@/config/firebaseConfig';
 import {
   kpiFormats,
   kpiTypes,
@@ -263,7 +264,19 @@ export default {
 
   methods: {
     submitForm() {
-      this.$emit('save', this.localKpi);
+      this.$emit('save', this.localKpi, () => {
+        if (this.localKpi.auto) {
+          this.testConnection();
+        }
+      });
+    },
+
+    async testConnection() {
+      try {
+        await functions.httpsCallable('fetchKpiDataTrigger')(this.localKpi.id);
+      } catch (error) {
+        throw new Error(error.message);
+      }
     },
 
     apiCurl: (kpi) =>

--- a/src/views/ItemAdmin/ItemAdminKPI.vue
+++ b/src/views/ItemAdmin/ItemAdminKPI.vue
@@ -89,13 +89,13 @@ export default {
   computed: {
     ...mapState(['kpis']),
     state() {
-      if (this.kpi.error) {
+      if (this.kpi.error && this.kpi.auto) {
         return 'error';
       }
-      if (this.kpi.valid) {
-        return 'valid';
+      if (this.loading) {
+        return 'loading';
       }
-      return 'loading';
+      return 'valid';
     },
     stateClass() {
       switch (this.state) {
@@ -159,12 +159,15 @@ export default {
   methods: {
     formatKPIValue,
 
-    async save(kpi) {
+    async save(kpi, afterSave) {
       this.loading = true;
       delete kpi.parent;
 
       try {
         await Kpi.update(kpi.id, kpi);
+        if (afterSave) {
+          afterSave();
+        }
         this.$toasted.show(this.$t('toaster.savedChanges'));
       } catch {
         this.$toasted.error(this.$t('toaster.error.save'));


### PR DESCRIPTION
Restore the functionality for testing a Google Sheets connection when saving a KPI by making an explicit test call instead of relying on the previous (removed) KPI update trigger.