### PR TITLE
Upgrade to Node 16

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -19,10 +19,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Use Node.js 14
+      - name: Use Node.js 16
         uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: 16
 
       - name: Populate env file
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [16.x]
 
     steps:
       - name: Checkout repository

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project will be documented in this file. The format 
 
 - Google Sheets integrations now expect full Google Sheets URLs instead of the
   sheet IDs.
+- Node 16 is now the default runtime for all Cloud Functions and when running
+  the app locally.
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ If you would like to check out how the application works, you can go to the demo
 
 ## Project requirements
 
-- Node 14.x
+- Node 16.x
 - Firebase >=8.x (v9 is not supported)
 - Firebase tools >9.x
 - Firebase Blaze plan - Pay as you go

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -26,7 +26,7 @@
         "firebase-functions-test": "^0.3.3"
       },
       "engines": {
-        "node": "14"
+        "node": "16"
       }
     },
     "node_modules/@fastify/busboy": {

--- a/functions/package.json
+++ b/functions/package.json
@@ -11,7 +11,7 @@
     "logs": "firebase functions:log"
   },
   "engines": {
-    "node": "14"
+    "node": "16"
   },
   "dependencies": {
     "@slack/web-api": "6.5.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -79,6 +79,9 @@
         "vite": "^2.9.13",
         "vite-plugin-vue2": "^1.9.0",
         "vue-template-compiler": "^2.6.14"
+      },
+      "engines": {
+        "node": "16"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
     "lint:style:fix": "stylelint 'src/**/*.scss' 'src/**/*.vue' --fix",
     "export_mock_data": "firebase emulators:export ./mock_data"
   },
+  "engines": {
+    "node": "16"
+  },
   "dependencies": {
     "@braid/griddle": "^2.3.1",
     "@fortawesome/fontawesome-free": "^5.15.4",


### PR DESCRIPTION
Upgrade to the Node 16 runtime for Cloud Functions, local scripts, and GitHub Actions.

The Cloud Functions should probably be updated piecewise and carefully since the previous attempt failed (see Trello card).