### PR TITLE
Add basic Gantt chart component

### DIFF
--- a/src/components/GanttChart.vue
+++ b/src/components/GanttChart.vue
@@ -13,14 +13,14 @@
         </div>
       </div>
       <div class="ticks">
-        <span class="tick-padding"></span>
+        <span class="ticks__padding"></span>
         <div
           v-for="m in months"
           :key="m.valueOf()"
-          class="tick"
+          class="ticks__tick"
           :style="`flex: 0 0 ${getDaysInMonth(m) * PPD}px`"
         ></div>
-        <span class="tick-padding"></span>
+        <span class="ticks__padding"></span>
       </div>
     </div>
     <div
@@ -29,8 +29,8 @@
       class="objective"
       :style="objectiveStyle(o)"
     >
-      <div class="tag">{{ item.name }}</div>
-      <div class="title">{{ o.name }}</div>
+      <div class="objective__tag">{{ item.name }}</div>
+      <div class="objective__title">{{ o.name }}</div>
       <progress-bar :progression="o.progression * 100" />
     </div>
     <div class="today-tick" :style="todayStyle()"></div>
@@ -198,7 +198,7 @@ export default {
 .ticks {
   display: flex;
 
-  .tick {
+  .ticks__tick {
     position: relative;
     z-index: 1;
     height: 0.75rem;
@@ -211,7 +211,7 @@ export default {
     }
   }
 
-  .tick-padding {
+  .ticks__padding {
     flex: 0 0 var(--end-padding);
     border-bottom: var(--line-width) solid var(--color-primary);
 
@@ -245,13 +245,13 @@ export default {
   box-shadow: 0 0 10px rgba(black, 0.1);
   cursor: pointer;
 
-  .tag {
+  .objective__tag {
     display: inline-block;
     padding: 0.5rem;
     background: var(--color-blue-5);
   }
 
-  .title {
+  .objective__title {
     max-width: 35rem;
     margin: 1.25rem 0;
     font-weight: 500;

--- a/src/components/GanttChart.vue
+++ b/src/components/GanttChart.vue
@@ -31,13 +31,7 @@
     >
       <div class="tag">{{ item.name }}</div>
       <div class="title">{{ o.name }}</div>
-      <progress
-        max="1"
-        :value="o.progression"
-        :aria-label="
-          $t('progress.complete', { progress: Math.round(o.progression * 100) })
-        "
-      />
+      <progress-bar :progression="o.progression * 100" />
     </div>
     <div class="today-tick" :style="todayStyle()"></div>
   </div>
@@ -57,6 +51,10 @@ import { capitalize, dateMonthYear } from '@/util';
 
 export default {
   name: 'GanttChart',
+
+  components: {
+    ProgressBar: () => import('@/components/ProgressBar.vue'),
+  },
 
   props: {
     objectives: {
@@ -262,28 +260,6 @@ export default {
   label {
     display: block;
     cursor: pointer;
-  }
-
-  progress {
-    display: block;
-    width: 100%;
-    height: 0.5rem;
-    margin-top: 0.25rem;
-    border: 0;
-    border-radius: 0;
-
-    &[value],
-    &[value]::-webkit-progress-bar {
-      background: var(--color-bg);
-    }
-
-    &[value]::-webkit-progress-value {
-      background: var(--color-blue-light);
-    }
-
-    &[value]::-moz-progress-bar {
-      background: var(--color-blue-light);
-    }
   }
 }
 </style>

--- a/src/components/GanttChart.vue
+++ b/src/components/GanttChart.vue
@@ -1,0 +1,296 @@
+<template>
+  <div class="gantt">
+    <div
+      class="month-wrapper"
+      @mousedown="startDrag"
+      @mousemove="drag"
+      @mouseup="stopDrag"
+      @mouseleave="stopDrag"
+    >
+      <div class="today" :style="todayStyle()">{{ $t('general.today') }}</div>
+      <div class="months">
+        <div
+          v-for="m in months"
+          :key="m.valueOf()"
+          class="month"
+          :style="`flex: 0 0 ${getDaysInMonth(m) * PPD}px`"
+        >
+          <span>{{ formatMonth(m) }}</span>
+        </div>
+      </div>
+      <div class="ticks">
+        <span class="tick-padding"></span>
+        <div
+          v-for="m in months"
+          :key="m.valueOf()"
+          class="tick"
+          :style="`flex: 0 0 ${getDaysInMonth(m) * PPD}px`"
+        ></div>
+        <span class="tick-padding"></span>
+      </div>
+    </div>
+    <div
+      v-for="o in orderedObjectives"
+      :key="o.id"
+      class="objective"
+      :style="objectiveStyle(o)"
+    >
+      <div class="tag">{{ item.name }}</div>
+      <div class="title">{{ o.name }}</div>
+      <progress
+        max="1"
+        :value="o.progression"
+        :aria-label="
+          $t('progress.complete', { progress: Math.round(o.progression * 100) })
+        "
+      />
+    </div>
+    <div class="today-tick" :style="todayStyle()"></div>
+  </div>
+</template>
+
+<script>
+import {
+  addMonths,
+  differenceInDays,
+  eachMonthOfInterval,
+  getDaysInMonth,
+  max,
+  min,
+  startOfMonth,
+} from 'date-fns';
+import { capitalize, dateMonthYear } from '@/util';
+
+export default {
+  name: 'GanttChart',
+
+  props: {
+    objectives: {
+      type: Array,
+      required: true,
+    },
+    item: {
+      type: Object,
+      required: true,
+    },
+  },
+
+  data() {
+    return {
+      PPD: 6, // Pixels per day
+      minPPD: 4.5,
+      lineWidth: '0.25rem',
+      endPadding: 75, // Padding in pixels before/after the first/last months
+      now: new Date(),
+      dragSense: 8,
+      dragSpeed: 0.25,
+      mouseX: null,
+      dragging: false,
+    };
+  },
+
+  computed: {
+    minDate() {
+      return min([this.now, ...this.objectives.map((o) => o.period.startDate.toDate())]);
+    },
+
+    maxDate() {
+      const date = max([
+        this.now,
+        ...this.objectives.map((o) => o.period.endDate.toDate()),
+      ]);
+      return addMonths(date, 1);
+    },
+
+    months() {
+      return eachMonthOfInterval({ start: this.minDate, end: this.maxDate });
+    },
+
+    orderedObjectives() {
+      return this.objectives
+        .slice()
+        .sort((a, b) => a.period.startDate - b.period.startDate);
+    },
+  },
+
+  methods: {
+    formatMonth(d) {
+      return capitalize(dateMonthYear(d));
+    },
+
+    todayStyle() {
+      return `transform: translateX(calc(${
+        differenceInDays(this.now, startOfMonth(this.minDate)) * this.PPD +
+        this.endPadding
+      }px + ${this.lineWidth} / 2 - 50%))`;
+    },
+
+    objectiveStyle(o) {
+      return [
+        `margin-left: ${
+          differenceInDays(o.period.startDate.toDate(), startOfMonth(this.minDate)) *
+            this.PPD +
+          this.endPadding
+        }px`,
+        `width: ${
+          differenceInDays(o.period.endDate.toDate(), o.period.startDate.toDate()) *
+          this.PPD
+        }px`,
+      ].join(';');
+    },
+
+    startDrag(e) {
+      this.mouseX = e.clientX;
+      this.dragging = true;
+    },
+
+    drag(e) {
+      if (this.dragging) {
+        if (e.clientX - this.mouseX > this.dragSense) {
+          this.mouseX = e.clientX;
+          this.PPD += this.dragSpeed;
+        } else if (e.clientX - this.mouseX < -this.dragSense) {
+          this.mouseX = e.clientX;
+          this.PPD = Math.max(this.minPPD, this.PPD - this.dragSpeed);
+        }
+      }
+    },
+
+    stopDrag() {
+      this.dragging = false;
+    },
+
+    addMonths,
+    differenceInDays,
+    getDaysInMonth,
+    startOfMonth,
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+.gantt {
+  --line-width: 0.2rem;
+  --end-padding: 75px;
+
+  position: relative;
+  min-height: 85vh;
+  margin-top: 0.5rem;
+  overflow-x: auto;
+}
+
+.month-wrapper {
+  margin-bottom: 1rem;
+  padding-top: 1.5rem;
+  cursor: col-resize;
+}
+
+.months {
+  display: flex;
+  margin-bottom: 0.5rem;
+  margin-left: var(--end-padding);
+  font-weight: 500;
+}
+
+.month {
+  position: relative;
+  z-index: 1;
+  height: 1rem;
+  user-select: none;
+
+  span {
+    position: absolute;
+    transform: translateX(calc(var(--line-width) / 2 - 50%));
+  }
+}
+
+.ticks {
+  display: flex;
+
+  .tick {
+    position: relative;
+    z-index: 1;
+    height: 0.75rem;
+    border-bottom: var(--line-width) solid var(--color-primary);
+    border-left: var(--line-width) solid var(--color-primary);
+
+    &:last-of-type {
+      flex-basis: var(--line-width) !important;
+      border-bottom: 0;
+    }
+  }
+
+  .tick-padding {
+    flex: 0 0 var(--end-padding);
+    border-bottom: var(--line-width) solid var(--color-primary);
+
+    &:last-of-type {
+      flex-basis: var(--end-padding);
+    }
+  }
+}
+
+.today {
+  display: inline-block;
+  height: 1.5rem;
+  color: var(--color-yellow);
+  font-weight: 500;
+}
+
+.today-tick {
+  position: absolute;
+  top: 3rem;
+  height: calc(100% - 3rem);
+  border-left: var(--line-width) dashed var(--color-yellow);
+}
+
+.objective {
+  position: relative;
+  z-index: 1;
+  margin: 1.25rem 0;
+  padding: 1rem;
+  line-height: 1.35;
+  background: var(--color-white);
+  box-shadow: 0 0 10px rgba(black, 0.1);
+  cursor: pointer;
+
+  .tag {
+    display: inline-block;
+    padding: 0.5rem;
+    background: var(--color-blue-5);
+  }
+
+  .title {
+    max-width: 35rem;
+    margin: 1.25rem 0;
+    font-weight: 500;
+  }
+
+  label {
+    display: block;
+    cursor: pointer;
+  }
+
+  progress {
+    display: block;
+    width: 100%;
+    height: 0.5rem;
+    margin-top: 0.25rem;
+    border: 0;
+    border-radius: 0;
+
+    &[value],
+    &[value]::-webkit-progress-bar {
+      background: var(--color-bg);
+    }
+
+    &[value]::-webkit-progress-value {
+      background: var(--color-blue-light);
+    }
+
+    &[value]::-moz-progress-bar {
+      background: var(--color-blue-light);
+    }
+  }
+}
+</style>

--- a/src/components/GanttChart.vue
+++ b/src/components/GanttChart.vue
@@ -1,12 +1,6 @@
 <template>
   <div class="gantt">
-    <div
-      class="month-wrapper"
-      @mousedown="startDrag"
-      @mousemove="drag"
-      @mouseup="stopDrag"
-      @mouseleave="stopDrag"
-    >
+    <div class="month-wrapper" @mousedown="startDrag">
       <div class="today" :style="todayStyle()">{{ $t('general.today') }}</div>
       <div class="months">
         <div
@@ -85,7 +79,6 @@ export default {
       dragSense: 8,
       dragSpeed: 0.25,
       mouseX: null,
-      dragging: false,
     };
   },
 
@@ -141,23 +134,23 @@ export default {
 
     startDrag(e) {
       this.mouseX = e.clientX;
-      this.dragging = true;
+      window.addEventListener('mousemove', this.drag);
+      window.addEventListener('mouseup', this.stopDrag);
     },
 
     drag(e) {
-      if (this.dragging) {
-        if (e.clientX - this.mouseX > this.dragSense) {
-          this.mouseX = e.clientX;
-          this.PPD += this.dragSpeed;
-        } else if (e.clientX - this.mouseX < -this.dragSense) {
-          this.mouseX = e.clientX;
-          this.PPD = Math.max(this.minPPD, this.PPD - this.dragSpeed);
-        }
+      if (e.clientX - this.mouseX > this.dragSense) {
+        this.mouseX = e.clientX;
+        this.PPD += this.dragSpeed;
+      } else if (e.clientX - this.mouseX < -this.dragSense) {
+        this.mouseX = e.clientX;
+        this.PPD = Math.max(this.minPPD, this.PPD - this.dragSpeed);
       }
     },
 
     stopDrag() {
-      this.dragging = false;
+      window.removeEventListener('mousemove', this.drag);
+      window.removeEventListener('mouseup', this.stopDrag);
     },
 
     addMonths,

--- a/src/locale/locales/en-US.json
+++ b/src/locale/locales/en-US.json
@@ -180,7 +180,8 @@
     "target": "Target",
     "selectRange": "Select a start and end date",
     "formErrors": "The form contains errors that must be corrected.",
-    "displayedAs": "Displayed as: "
+    "displayedAs": "Displayed as: ",
+    "today": "Today"
   },
   "about": {
     "about": "About",

--- a/src/locale/locales/nb-NO.json
+++ b/src/locale/locales/nb-NO.json
@@ -178,7 +178,8 @@
     "target": "Målsetting",
     "selectRange": "Velg start- og sluttdato",
     "formErrors": "Skjemaet inneholder feil som må rettes.",
-    "displayedAs": "Vises som: "
+    "displayedAs": "Vises som: ",
+    "today": "I dag"
   },
   "about": {
     "about": "Om",

--- a/src/util/format.js
+++ b/src/util/format.js
@@ -7,6 +7,7 @@ const o = { locale };
 export const dateLong = (d) => format(d, 'PPP', o);
 export const dateLongCompact = (d) => format(d, 'PP', o);
 export const dateShort = (d) => format(d, 'P', o);
+export const dateMonthYear = (d) => format(d, 'MMMM y', o);
 export const dateTimeShort = (d) => format(d, 'Pp', o);
 export const dateTimeLong = (d) => format(d, 'PPPp', o);
 

--- a/src/util/index.js
+++ b/src/util/index.js
@@ -1,6 +1,7 @@
 export { dateLong } from './format';
 export { dateLongCompact } from './format';
 export { dateShort } from './format';
+export { dateMonthYear } from './format';
 export { dateTimeShort } from './format';
 export { dateTimeLong } from './format';
 export { periodDates } from './format';
@@ -12,4 +13,5 @@ export { default as tableOfContent } from './tableOfContent';
 export { default as toastArchiveAndRevert } from './toastUtils';
 export { default as validateEmail } from './validateEmail';
 
+export const capitalize = (str) => str.charAt(0).toUpperCase() + str.slice(1);
 export const getRandomInt = (max) => Math.floor(Math.random() * max);


### PR DESCRIPTION
Add a basic version of a Gantt chart display of objectives.

The `gantt-wip` branch can be used to test the component.