### PR TITLE
Limit precision of measurement value display

### DIFF
--- a/src/components/modals/KPIProgressModal.vue
+++ b/src/components/modals/KPIProgressModal.vue
@@ -125,7 +125,10 @@ export default {
     },
     recordValue: {
       get() {
-        return this.typePercentage ? this.thisRecord.value * 100 : this.thisRecord.value;
+        const n = this.typePercentage
+          ? this.thisRecord.value * 100
+          : this.thisRecord.value;
+        return parseFloat(n.toFixed(4));
       },
       set(val) {
         this.thisRecord.value = this.typePercentage ? val / 100 : val;


### PR DESCRIPTION
Limit the precision of displayed measurement values to avoid JavaScript floating point precision errors.