### PR TITLE
Improve progress bar styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ All notable changes to this project will be documented in this file. The format 
   (plain) "measurements".
 - Any currently active period is now focused by default, instead of most
   recent, when visiting the OKR view.
+- Progress bar styling has been improved for better differentiation between the
+  empty and filled state.
 
 ### Fixed
 - Period progression is now updated when an objective is moved between periods.

--- a/src/components/ItemRow.vue
+++ b/src/components/ItemRow.vue
@@ -38,13 +38,10 @@
         </div>
       </div>
 
-      <progress-bar
-        v-tooltip="`${progression}%`"
-        class="progress-bar"
-        :progression="progression"
-      />
-
-      <i class="item__chevron fas fa-chevron-right" />
+      <div class="item__progress">
+        <progress-bar :progression="progression" />
+        <i class="item__chevron fas fa-chevron-right" />
+      </div>
     </router-link>
   </div>
 </template>
@@ -172,18 +169,25 @@ export default {
   transition: all 0.1s ease-in;
 }
 
-.progress-bar {
-  flex-shrink: 0;
-  width: span(1, 0, span(6)) !important;
-  margin-top: 0.5rem;
+.item__progress {
+  display: flex;
+  flex: 0 1 10rem;
+  gap: 1rem;
+  align-items: flex-start;
 
   @media screen and (min-width: bp(l)) {
-    width: span(2, 0, span(6));
+    flex-basis: 13rem;
+  }
+
+  .progress {
+    flex: 1 1 auto;
+    margin-top: 0.5rem;
   }
 }
 
 .item__kpis {
   display: none;
+  flex: 1 1 min-content;
   flex-flow: row-reverse wrap;
   margin-top: 0.15rem;
   margin-right: 1rem;

--- a/src/components/KeyResultRow.vue
+++ b/src/components/KeyResultRow.vue
@@ -26,6 +26,7 @@
       <progress-bar
         :progression="progressDetails.percentageCompleted"
         :is-compact="!isDetailedView"
+        :dark="true"
         class="keyResult__progressBar"
         :class="{ 'keyResult__progressBar--isDetailedView': isDetailedView }"
       />

--- a/src/components/ProgressBar.vue
+++ b/src/components/ProgressBar.vue
@@ -1,14 +1,17 @@
 <template>
-  <div
-    v-tooltip="`${progression}%`"
-    class="progression__container"
-    :class="{ 'progression__container--isCompact': isCompact }"
-  >
-    <div class="progression__bar" :style="{ width: progressBarWidth }"></div>
+  <div v-tooltip="label" class="progress">
+    <progress
+      :class="{ 'progress--isCompact': isCompact, 'progress--dark': dark }"
+      max="100"
+      :value="Math.min(progression, 100)"
+      :aria-label="label"
+    />
   </div>
 </template>
 
 <script>
+import i18n from '@/locale/i18n';
+
 export default {
   name: 'ProgressBar',
 
@@ -21,37 +24,50 @@ export default {
       type: Boolean,
       default: true,
     },
+    dark: {
+      type: Boolean,
+      default: false,
+    },
   },
-  computed: {
-    progressBarWidth() {
-      if (!this.progression || this.progression < 0) {
-        return 0;
-      }
-      if (this.progression > 100) {
-        return '100%';
-      }
 
-      return `${this.progression}%`;
+  computed: {
+    label() {
+      return i18n.t('progress.complete', {
+        progress: Math.round(this.progression),
+      });
     },
   },
 };
 </script>
 
 <style lang="scss" scoped>
-.progression__container {
-  position: relative;
+progress {
+  display: block;
   width: 100%;
   height: 0.625rem;
-  margin-right: 1rem;
-  background: var(--color-blue-dark-40);
+  border: 0;
+  border-radius: 0;
 
-  &--isCompact {
+  &[value],
+  &[value]::-webkit-progress-bar {
+    background: var(--color-gray);
+  }
+
+  &[value]::-webkit-progress-value {
+    background: var(--color-secondary);
+  }
+
+  &[value]::-moz-progress-bar {
+    background: var(--color-secondary);
+  }
+
+  &.progress--isCompact {
     height: 0.3125rem;
   }
-}
 
-.progression__bar {
-  height: 100%;
-  background: var(--color-secondary);
+  &.progress--dark[value],
+  &.progress--dark[value]::-webkit-progress-bar {
+    background: var(--color-blue-dark-40);
+  }
 }
 </style>

--- a/src/locale/locales/en-US.json
+++ b/src/locale/locales/en-US.json
@@ -579,6 +579,7 @@
     "done": "done",
     "remaining": "{unit} remaining",
     "remainingOf": "of {progress}",
+    "complete": "{progress}% complete",
     "completedMessages": {
       "1": "You guys are nailing it!",
       "2": "Well done, guys!",

--- a/src/locale/locales/nb-NO.json
+++ b/src/locale/locales/nb-NO.json
@@ -577,6 +577,7 @@
     "done": "fullført",
     "remaining": "{unit} gjenstår",
     "remainingOf": "av {progress}",
+    "complete": "{progress} % fullført",
     "completedMessages": {
       "1": "Nå er dere gode!",
       "2": "Dødsbra jobba, folkens!",

--- a/src/views/KeyResultHome.vue
+++ b/src/views/KeyResultHome.vue
@@ -35,6 +35,7 @@
             <progress-bar
               :progression="progressDetails.percentageCompleted"
               :is-compact="false"
+              :dark="true"
               class="key-result-row__progressBar"
             />
           </div>


### PR DESCRIPTION
Improve the progress bar styling to better differentiate between the empty and filled states. The new style is currently only used on the front page since it works best on a light background, but over time we should converge on that style everywhere.

The internals of the `ProgressBar` component have also been changed to render an actual `<progress>` element instead of a `<div>`.