### PR TITLE
Bump `firebase-tools`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -66,7 +66,7 @@
         "eslint-plugin-import": "^2.26.0",
         "eslint-plugin-prettier": "^4.2.1",
         "eslint-plugin-vue": "^9.7.0",
-        "firebase-tools": "^11.22.0",
+        "firebase-tools": "^11.24.0",
         "firestore-jest-mock": "^0.17.0",
         "jest": "^27.4.7",
         "postcss-html": "1.5.0",
@@ -7083,9 +7083,9 @@
       }
     },
     "node_modules/firebase-tools": {
-      "version": "11.22.0",
-      "resolved": "https://registry.npmjs.org/firebase-tools/-/firebase-tools-11.22.0.tgz",
-      "integrity": "sha512-wTM/bjceNKipTQTk1ocpAvqg9075L/wWAzScLB+M9uzYSBaz8xA0lfOPo0e6L0AoXpOXJBkOBTlcJ6No0LQ66w==",
+      "version": "11.24.0",
+      "resolved": "https://registry.npmjs.org/firebase-tools/-/firebase-tools-11.24.0.tgz",
+      "integrity": "sha512-fqwI6rBCvMs3E2pLYEzJYPIB+cmLxV9l+bX7VZHpxhUvbZZrM7271C8sjiBdIh97ue+BvgXHqTDlsW88ZZXt1g==",
       "dev": true,
       "hasShrinkwrap": true,
       "dependencies": {
@@ -7137,7 +7137,7 @@
         "stream-chain": "^2.2.4",
         "stream-json": "^1.7.3",
         "strip-ansi": "^6.0.1",
-        "superstatic": "^9.0.2",
+        "superstatic": "^9.0.3",
         "tar": "^6.1.11",
         "tcp-port-used": "^1.0.2",
         "tmp": "^0.2.1",
@@ -7636,9 +7636,9 @@
       "dev": true
     },
     "node_modules/firebase-tools/node_modules/@types/node": {
-      "version": "14.18.18",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.18.tgz",
-      "integrity": "sha512-B9EoJFjhqcQ9OmQrNorItO+OwEOORNn3S31WuiHvZY/dm9ajkB7AKD/8toessEtHHNL+58jofbq7hMMY9v4yig==",
+      "version": "14.18.36",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.36.tgz",
+      "integrity": "sha512-FXKWbsJ6a1hIrRxv+FoukuHnGTgEzKYGi7kilfMae96AL9UNkPFNWJEEYWzdRI9ooIkbr4AKldyuSTLql06vLQ==",
       "dev": true
     },
     "node_modules/firebase-tools/node_modules/abbrev": {
@@ -9429,26 +9429,29 @@
       }
     },
     "node_modules/firebase-tools/node_modules/eslint-visitor-keys": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.1.0.tgz",
-      "integrity": "sha512-yWJFpu4DtjsWKkt5GeNBBuZMlNcYVs6vRCLoCVEJrTjaSB6LC98gFipNK/erM2Heg/E8mIK+hXG/pJMLK+eRZA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+      "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/firebase-tools/node_modules/espree": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.0.tgz",
-      "integrity": "sha512-d/5nCsb0JcqsSEeQzFZ8DH1RmxPcglRWh24EFTlUEmCKoehXGdpsx0RkHDubqUI8LSAIKMQp4r9SzQ3n+sm4HQ==",
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.4.1.tgz",
+      "integrity": "sha512-XwctdmTO6SIvCzd9810yyNzIrOrqNYV9Koizx4C/mRhf9uq0o4yHoCEU/670pOxOL/MSraektvSAji79kX90Vg==",
       "dev": true,
       "dependencies": {
-        "acorn": "^8.7.0",
-        "acorn-jsx": "^5.3.1",
-        "eslint-visitor-keys": "^3.1.0"
+        "acorn": "^8.8.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/firebase-tools/node_modules/esprima": {
@@ -10787,9 +10790,9 @@
       }
     },
     "node_modules/firebase-tools/node_modules/http-cache-semantics": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
       "dev": true,
       "optional": true
     },
@@ -11008,9 +11011,9 @@
       "dev": true
     },
     "node_modules/firebase-tools/node_modules/inquirer": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.0.tgz",
-      "integrity": "sha512-0crLweprevJ02tTuA6ThpoAERAGyVILC4sS74uib58Xf/zSr1/ZWtmm7D5CI+bSQEaA04f0K7idaHpQbSWgiVQ==",
+      "version": "8.2.5",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.5.tgz",
+      "integrity": "sha512-QAgPDQMEgrDssk1XiwwHoOGYF9BAbUcc1+j+FhEvaOt8/cKRqyLn0U5qA6F74fGhTMGxf92pOvPBeh29jQJDTQ==",
       "dev": true,
       "dependencies": {
         "ansi-escapes": "^4.2.1",
@@ -11023,13 +11026,14 @@
         "mute-stream": "0.0.8",
         "ora": "^5.4.1",
         "run-async": "^2.4.0",
-        "rxjs": "^7.2.0",
+        "rxjs": "^7.5.5",
         "string-width": "^4.1.0",
         "strip-ansi": "^6.0.0",
-        "through": "^2.3.6"
+        "through": "^2.3.6",
+        "wrap-ansi": "^7.0.0"
       },
       "engines": {
-        "node": ">=8.0.0"
+        "node": ">=12.0.0"
       }
     },
     "node_modules/firebase-tools/node_modules/inquirer/node_modules/ansi-escapes": {
@@ -11281,9 +11285,9 @@
       }
     },
     "node_modules/firebase-tools/node_modules/is-path-inside": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.2.tgz",
-      "integrity": "sha512-/2UGPSgmtqwo1ktx8NDHjuPwZWmHhO+gj0f93EkhLB5RgW9RZevWYYlIkS6zePc6U2WpOdQYIwHe9YC4DWEBVg==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
       "dev": true,
       "engines": {
         "node": ">=8"
@@ -12089,9 +12093,9 @@
       "dev": true
     },
     "node_modules/firebase-tools/node_modules/marked": {
-      "version": "4.0.14",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.14.tgz",
-      "integrity": "sha512-HL5sSPE/LP6U9qKgngIIPTthuxC0jrfxpYMZ3LdGDD3vTnLs59m2Z7r6+LNDR3ToqEQdkKd6YaaEfJhodJmijQ==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.2.12.tgz",
+      "integrity": "sha512-yr8hSKa3Fv4D3jdZmtMMPghgVt6TWbk86WQaWhDloQjRSQhMMYCAro7jP7VDJrjjdV8pxVxMssXS8B8Y5DZ5aw==",
       "dev": true,
       "bin": {
         "marked": "bin/marked.js"
@@ -13882,13 +13886,13 @@
       }
     },
     "node_modules/firebase-tools/node_modules/superstatic": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/superstatic/-/superstatic-9.0.2.tgz",
-      "integrity": "sha512-eKX9qubOaJbtdxn4gWhVVMXuno8cn0WPKOYgLAmLwYiHafrASXAIXHzL3Jx7w06yXiaM5e1DA2Ezeb08iV28+A==",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/superstatic/-/superstatic-9.0.3.tgz",
+      "integrity": "sha512-e/tmW0bsnQ/33ivK6y3CapJT0Ovy4pk/ohNPGhIAGU2oasoNLRQ1cv6enua09NU9w6Y0H/fBu07cjzuiWvLXxw==",
       "dev": true,
       "dependencies": {
         "basic-auth-connect": "^1.0.0",
-        "commander": "^9.4.0",
+        "commander": "^10.0.0",
         "compression": "^1.7.0",
         "connect": "^3.7.0",
         "destroy": "^1.0.4",
@@ -13898,7 +13902,7 @@
         "join-path": "^1.1.1",
         "lodash": "^4.17.19",
         "mime-types": "^2.1.35",
-        "minimatch": "^5.1.0",
+        "minimatch": "^6.1.6",
         "morgan": "^1.8.2",
         "on-finished": "^2.2.0",
         "on-headers": "^1.0.0",
@@ -13926,12 +13930,12 @@
       }
     },
     "node_modules/firebase-tools/node_modules/superstatic/node_modules/commander": {
-      "version": "9.4.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.0.tgz",
-      "integrity": "sha512-sRPT+umqkz90UA8M1yqYfnHlZA7fF6nSphDtxeywPZ49ysjxDQybzk13CL+mXekDRG92skbcqCLVovuCusNmFw==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.0.tgz",
+      "integrity": "sha512-zS5PnTI22FIRM6ylNW8G4Ap0IEOyk62fhLSD0+uHRT9McRCLGpkVNvao4bjimpK/GShynyQkFFxHhwMcETmduA==",
       "dev": true,
       "engines": {
-        "node": "^12.20.0 || >=14"
+        "node": ">=14"
       }
     },
     "node_modules/firebase-tools/node_modules/superstatic/node_modules/isarray": {
@@ -13941,15 +13945,18 @@
       "dev": true
     },
     "node_modules/firebase-tools/node_modules/superstatic/node_modules/minimatch": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.2.tgz",
-      "integrity": "sha512-bNH9mmM9qsJ2X4r2Nat1B//1dJVcn3+iBLa3IgqJ7EbGaDNepL9QSHOxN4ng33s52VMMhhIfgCYDk3C4ZmlDAg==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-6.2.0.tgz",
+      "integrity": "sha512-sauLxniAmvnhhRjFwPNnJKaPFYyddAgbYdeUpHULtCT/GhzdCx/MDNy+Y40lBxTQUrMzDE8e0S43Z5uqfO0REg==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/firebase-tools/node_modules/superstatic/node_modules/path-to-regexp": {
@@ -27738,9 +27745,9 @@
       }
     },
     "firebase-tools": {
-      "version": "11.22.0",
-      "resolved": "https://registry.npmjs.org/firebase-tools/-/firebase-tools-11.22.0.tgz",
-      "integrity": "sha512-wTM/bjceNKipTQTk1ocpAvqg9075L/wWAzScLB+M9uzYSBaz8xA0lfOPo0e6L0AoXpOXJBkOBTlcJ6No0LQ66w==",
+      "version": "11.24.0",
+      "resolved": "https://registry.npmjs.org/firebase-tools/-/firebase-tools-11.24.0.tgz",
+      "integrity": "sha512-fqwI6rBCvMs3E2pLYEzJYPIB+cmLxV9l+bX7VZHpxhUvbZZrM7271C8sjiBdIh97ue+BvgXHqTDlsW88ZZXt1g==",
       "dev": true,
       "requires": {
         "@google-cloud/pubsub": "^3.0.1",
@@ -27791,7 +27798,7 @@
         "stream-chain": "^2.2.4",
         "stream-json": "^1.7.3",
         "strip-ansi": "^6.0.1",
-        "superstatic": "^9.0.2",
+        "superstatic": "^9.0.3",
         "tar": "^6.1.11",
         "tcp-port-used": "^1.0.2",
         "tmp": "^0.2.1",
@@ -28206,9 +28213,9 @@
           "dev": true
         },
         "@types/node": {
-          "version": "14.18.18",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.18.tgz",
-          "integrity": "sha512-B9EoJFjhqcQ9OmQrNorItO+OwEOORNn3S31WuiHvZY/dm9ajkB7AKD/8toessEtHHNL+58jofbq7hMMY9v4yig==",
+          "version": "14.18.36",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.36.tgz",
+          "integrity": "sha512-FXKWbsJ6a1hIrRxv+FoukuHnGTgEzKYGi7kilfMae96AL9UNkPFNWJEEYWzdRI9ooIkbr4AKldyuSTLql06vLQ==",
           "dev": true
         },
         "abbrev": {
@@ -29627,20 +29634,20 @@
           }
         },
         "eslint-visitor-keys": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.1.0.tgz",
-          "integrity": "sha512-yWJFpu4DtjsWKkt5GeNBBuZMlNcYVs6vRCLoCVEJrTjaSB6LC98gFipNK/erM2Heg/E8mIK+hXG/pJMLK+eRZA==",
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+          "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
           "dev": true
         },
         "espree": {
-          "version": "9.3.0",
-          "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.0.tgz",
-          "integrity": "sha512-d/5nCsb0JcqsSEeQzFZ8DH1RmxPcglRWh24EFTlUEmCKoehXGdpsx0RkHDubqUI8LSAIKMQp4r9SzQ3n+sm4HQ==",
+          "version": "9.4.1",
+          "resolved": "https://registry.npmjs.org/espree/-/espree-9.4.1.tgz",
+          "integrity": "sha512-XwctdmTO6SIvCzd9810yyNzIrOrqNYV9Koizx4C/mRhf9uq0o4yHoCEU/670pOxOL/MSraektvSAji79kX90Vg==",
           "dev": true,
           "requires": {
-            "acorn": "^8.7.0",
-            "acorn-jsx": "^5.3.1",
-            "eslint-visitor-keys": "^3.1.0"
+            "acorn": "^8.8.0",
+            "acorn-jsx": "^5.3.2",
+            "eslint-visitor-keys": "^3.3.0"
           }
         },
         "esprima": {
@@ -30700,9 +30707,9 @@
           "dev": true
         },
         "http-cache-semantics": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-          "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+          "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
           "dev": true,
           "optional": true
         },
@@ -30873,9 +30880,9 @@
           "dev": true
         },
         "inquirer": {
-          "version": "8.2.0",
-          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.0.tgz",
-          "integrity": "sha512-0crLweprevJ02tTuA6ThpoAERAGyVILC4sS74uib58Xf/zSr1/ZWtmm7D5CI+bSQEaA04f0K7idaHpQbSWgiVQ==",
+          "version": "8.2.5",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.5.tgz",
+          "integrity": "sha512-QAgPDQMEgrDssk1XiwwHoOGYF9BAbUcc1+j+FhEvaOt8/cKRqyLn0U5qA6F74fGhTMGxf92pOvPBeh29jQJDTQ==",
           "dev": true,
           "requires": {
             "ansi-escapes": "^4.2.1",
@@ -30888,10 +30895,11 @@
             "mute-stream": "0.0.8",
             "ora": "^5.4.1",
             "run-async": "^2.4.0",
-            "rxjs": "^7.2.0",
+            "rxjs": "^7.5.5",
             "string-width": "^4.1.0",
             "strip-ansi": "^6.0.0",
-            "through": "^2.3.6"
+            "through": "^2.3.6",
+            "wrap-ansi": "^7.0.0"
           },
           "dependencies": {
             "ansi-escapes": {
@@ -31066,9 +31074,9 @@
           "dev": true
         },
         "is-path-inside": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.2.tgz",
-          "integrity": "sha512-/2UGPSgmtqwo1ktx8NDHjuPwZWmHhO+gj0f93EkhLB5RgW9RZevWYYlIkS6zePc6U2WpOdQYIwHe9YC4DWEBVg==",
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+          "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
           "dev": true
         },
         "is-stream": {
@@ -31754,9 +31762,9 @@
           "requires": {}
         },
         "marked": {
-          "version": "4.0.14",
-          "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.14.tgz",
-          "integrity": "sha512-HL5sSPE/LP6U9qKgngIIPTthuxC0jrfxpYMZ3LdGDD3vTnLs59m2Z7r6+LNDR3ToqEQdkKd6YaaEfJhodJmijQ==",
+          "version": "4.2.12",
+          "resolved": "https://registry.npmjs.org/marked/-/marked-4.2.12.tgz",
+          "integrity": "sha512-yr8hSKa3Fv4D3jdZmtMMPghgVt6TWbk86WQaWhDloQjRSQhMMYCAro7jP7VDJrjjdV8pxVxMssXS8B8Y5DZ5aw==",
           "dev": true
         },
         "marked-terminal": {
@@ -33163,13 +33171,13 @@
           "dev": true
         },
         "superstatic": {
-          "version": "9.0.2",
-          "resolved": "https://registry.npmjs.org/superstatic/-/superstatic-9.0.2.tgz",
-          "integrity": "sha512-eKX9qubOaJbtdxn4gWhVVMXuno8cn0WPKOYgLAmLwYiHafrASXAIXHzL3Jx7w06yXiaM5e1DA2Ezeb08iV28+A==",
+          "version": "9.0.3",
+          "resolved": "https://registry.npmjs.org/superstatic/-/superstatic-9.0.3.tgz",
+          "integrity": "sha512-e/tmW0bsnQ/33ivK6y3CapJT0Ovy4pk/ohNPGhIAGU2oasoNLRQ1cv6enua09NU9w6Y0H/fBu07cjzuiWvLXxw==",
           "dev": true,
           "requires": {
             "basic-auth-connect": "^1.0.0",
-            "commander": "^9.4.0",
+            "commander": "^10.0.0",
             "compression": "^1.7.0",
             "connect": "^3.7.0",
             "destroy": "^1.0.4",
@@ -33179,7 +33187,7 @@
             "join-path": "^1.1.1",
             "lodash": "^4.17.19",
             "mime-types": "^2.1.35",
-            "minimatch": "^5.1.0",
+            "minimatch": "^6.1.6",
             "morgan": "^1.8.2",
             "on-finished": "^2.2.0",
             "on-headers": "^1.0.0",
@@ -33199,9 +33207,9 @@
               }
             },
             "commander": {
-              "version": "9.4.0",
-              "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.0.tgz",
-              "integrity": "sha512-sRPT+umqkz90UA8M1yqYfnHlZA7fF6nSphDtxeywPZ49ysjxDQybzk13CL+mXekDRG92skbcqCLVovuCusNmFw==",
+              "version": "10.0.0",
+              "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.0.tgz",
+              "integrity": "sha512-zS5PnTI22FIRM6ylNW8G4Ap0IEOyk62fhLSD0+uHRT9McRCLGpkVNvao4bjimpK/GShynyQkFFxHhwMcETmduA==",
               "dev": true
             },
             "isarray": {
@@ -33211,9 +33219,9 @@
               "dev": true
             },
             "minimatch": {
-              "version": "5.1.2",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.2.tgz",
-              "integrity": "sha512-bNH9mmM9qsJ2X4r2Nat1B//1dJVcn3+iBLa3IgqJ7EbGaDNepL9QSHOxN4ng33s52VMMhhIfgCYDk3C4ZmlDAg==",
+              "version": "6.2.0",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-6.2.0.tgz",
+              "integrity": "sha512-sauLxniAmvnhhRjFwPNnJKaPFYyddAgbYdeUpHULtCT/GhzdCx/MDNy+Y40lBxTQUrMzDE8e0S43Z5uqfO0REg==",
               "dev": true,
               "requires": {
                 "brace-expansion": "^2.0.1"

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-vue": "^9.7.0",
-    "firebase-tools": "^11.22.0",
+    "firebase-tools": "^11.24.0",
     "firestore-jest-mock": "^0.17.0",
     "jest": "^27.4.7",
     "postcss-html": "1.5.0",


### PR DESCRIPTION
Upgrade `firebase-tools`, mainly to be able to upgrade its vulnerable `http-cache-semantics` dependency.

Fixes https://github.com/oslokommune/okr-tracker/security/dependabot/86.