### PR TITLE
Fix disappearing date picker on KPI details page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [UNRELEASED]
 
+### Fixed
+
+- The date picker on the KPI details page no longer disappears when the selected
+  period doesn't contain any measurements.
+
 ### Changed
 
 - The period selector is moved to a more prominent position in the item tab bar.

--- a/src/components/widgets/WidgetKpiFilter.vue
+++ b/src/components/widgets/WidgetKpiFilter.vue
@@ -1,6 +1,6 @@
 <template>
   <widget :title="$t('keyResultPage.filter')" size="small">
-    <label v-if="progress.length" class="form-field">
+    <label class="form-field">
       <span class="form-label">{{ $t('period.dateRange') }}</span>
       <flat-pickr
         ref="datePicker"
@@ -9,6 +9,7 @@
         class="form-control flatpickr-input"
         name="date"
         :placeholder="$t('general.selectRange')"
+        :disabled="!progress.length"
       ></flat-pickr>
     </label>
 
@@ -72,3 +73,9 @@ export default {
   },
 };
 </script>
+
+<style lang="scss" scoped>
+::v-deep .flatpickr-input[disabled] {
+  cursor: not-allowed;
+}
+</style>

--- a/src/components/widgets/WidgetProgressHistory/WidgetProgressHistory.vue
+++ b/src/components/widgets/WidgetProgressHistory/WidgetProgressHistory.vue
@@ -7,7 +7,7 @@
         v-else-if="!progress.length || progress.length === 0"
         :icon="'history'"
         :heading="$t('widget.history.empty.heading')"
-        :body="noValuesMessage || $t('widget.history.empty.body')"
+        :body="noValuesMessage"
       />
 
       <table v-else class="table">
@@ -155,8 +155,7 @@ export default {
     },
     noValuesMessage: {
       type: String,
-      required: false,
-      default: null,
+      required: true,
     },
   },
 

--- a/src/locale/locales/en-US.json
+++ b/src/locale/locales/en-US.json
@@ -437,7 +437,7 @@
   },
   "empty": {
     "noKeyResultProgress": "This key result has no registered values.",
-    "noKPIProgress": "This measurement has no registered values.",
+    "noKPIProgress": "This measurement has no registered values in the period.",
     "noKeyResults": {
       "heading": "No key results",
       "body": "Oops! Could not find any key results.",
@@ -505,8 +505,7 @@
       "showComments": "Show comments",
       "hideComments": "Hide comments",
       "empty": {
-        "heading": "No history",
-        "body": "No values registered for this item."
+        "heading": "No history"
       },
       "overwriteWarning": "Note: This change will overwrite existing value for chosen date ({date}): {value}."
     }

--- a/src/locale/locales/en-US.json
+++ b/src/locale/locales/en-US.json
@@ -437,7 +437,8 @@
   },
   "empty": {
     "noKeyResultProgress": "This key result has no registered values.",
-    "noKPIProgress": "This measurement has no registered values in the period.",
+    "noKPIProgress": "This measurement has no registered values.",
+    "noKPIProgressInPeriod": "This measurement has no registered values in the period.",
     "noKeyResults": {
       "heading": "No key results",
       "body": "Oops! Could not find any key results.",

--- a/src/locale/locales/nb-NO.json
+++ b/src/locale/locales/nb-NO.json
@@ -435,7 +435,8 @@
   },
   "empty": {
     "noKeyResultProgress": "Dette nøkkelresultatet har ingen registrerte verdier.",
-    "noKPIProgress": "Denne målingen har ingen registrerte verdier i perioden.",
+    "noKPIProgress": "Denne målingen har ingen registrerte verdier.",
+    "noKPIProgressInPeriod": "Denne målingen har ingen registrerte verdier i perioden.",
     "noKeyResults": {
       "heading": "Ingen nøkkelresultater",
       "body": "Oops! Her er finnes det ingen nøkkelresultater ennå.",

--- a/src/locale/locales/nb-NO.json
+++ b/src/locale/locales/nb-NO.json
@@ -435,7 +435,7 @@
   },
   "empty": {
     "noKeyResultProgress": "Dette nøkkelresultatet har ingen registrerte verdier.",
-    "noKPIProgress": "Denne målingen har ingen registrerte verdier.",
+    "noKPIProgress": "Denne målingen har ingen registrerte verdier i perioden.",
     "noKeyResults": {
       "heading": "Ingen nøkkelresultater",
       "body": "Oops! Her er finnes det ingen nøkkelresultater ennå.",
@@ -503,8 +503,7 @@
       "showComments": "Vis kommentarer",
       "hideComments": "Skjul kommentarer",
       "empty": {
-        "heading": "Ingen historikk",
-        "body": "Ingen verdier registrert for dette elementet."
+        "heading": "Ingen historikk"
       },
       "overwriteWarning": "Merk: Denne endringen overskriver eksisterende måleverdi for valgt dato ({date}): {value}."
     }

--- a/src/views/KpiHome.vue
+++ b/src/views/KpiHome.vue
@@ -27,9 +27,8 @@
       />
     </main>
 
-    <aside v-if="filteredProgress.length" class="aside widgets">
+    <aside class="aside widgets">
       <widget-kpi-filter
-        v-if="filteredProgress.length"
         :range="range"
         :progress="progress"
         @listen="handleChange"
@@ -46,7 +45,7 @@
 
 <script>
 import { mapGetters, mapState } from 'vuex';
-import { extent } from 'd3-array';
+import { extent, min } from 'd3-array';
 import { endOfDay } from 'date-fns';
 import { db } from '@/config/firebaseConfig';
 import Progress from '@/db/Kpi/Progress';
@@ -167,22 +166,27 @@ export default {
     },
 
     renderGraph() {
+      if (!this.graph) {
+        return;
+      }
+
       const [startValue, targetValue] = extent(
         this.filteredProgress.map(({ value }) => value)
       );
-      const [startDate, endDate] = extent(
-        this.filteredProgress.map(({ timestamp }) => timestamp)
-      );
 
-      if (!this.graph || startValue === undefined || targetValue === undefined) {
-        return;
+      let startDate = new Date();
+
+      if (this.startDate) {
+        startDate = this.startDate;
+      } else if (this.filteredProgress.length) {
+        startDate = min(this.filteredProgress.map((p) => p.timestamp)).toDate();
       }
 
       this.graph.render({
         startValue,
         targetValue,
-        startDate: startDate.toDate(),
-        endDate: this.isFiltered ? endDate.toDate() : new Date(),
+        startDate,
+        endDate: this.endDate || new Date(),
         progress: this.filteredProgress,
         kpi: this.activeKpi,
       });

--- a/src/views/KpiHome.vue
+++ b/src/views/KpiHome.vue
@@ -21,18 +21,16 @@
         :is-loading="isLoading"
         :value-formatter="_formatKPIValue"
         :date-formatter="dateShort"
-        :no-values-message="$t('empty.noKPIProgress')"
+        :no-values-message="
+          isFiltered ? $t('empty.noKPIProgressInPeriod') : $t('empty.noKPIProgress')
+        "
         @update-record="updateProgressRecord"
         @delete-record="deleteProgressRecord"
       />
     </main>
 
     <aside class="aside widgets">
-      <widget-kpi-filter
-        :range="range"
-        :progress="progress"
-        @listen="handleChange"
-      />
+      <widget-kpi-filter :range="range" :progress="progress" @listen="handleChange" />
     </aside>
 
     <progress-modal
@@ -83,7 +81,6 @@ export default {
     startDate: null,
     endDate: null,
     filteredProgress: [],
-    isFiltered: false,
     isLoading: false,
     showValueModal: false,
   }),
@@ -91,6 +88,10 @@ export default {
   computed: {
     ...mapState(['activeKpi']),
     ...mapGetters(['hasEditRights']),
+
+    isFiltered() {
+      return this.startDate && this.endDate;
+    },
   },
 
   watch: {
@@ -193,13 +194,13 @@ export default {
     },
 
     filterProgress() {
-      if (!this.startDate && !this.endDate) {
-        this.filteredProgress = this.progress;
-      } else {
+      if (this.isFiltered) {
         this.filteredProgress = this.progress.filter(
           (a) =>
             a.timestamp.toDate() > this.startDate && a.timestamp.toDate() < this.endDate
         );
+      } else {
+        this.filteredProgress = this.progress;
       }
 
       // Filter out any duplicate measurement values for each date
@@ -241,7 +242,6 @@ export default {
       const [startDate, endDate] = range;
       this.startDate = startDate;
       this.endDate = endOfDay(endDate);
-      this.isFiltered = true;
 
       this.$router
         .push({


### PR DESCRIPTION
Don't have the date picker on the KPI details page disappear even if there are no measurements in the selected period.