### PR TITLE
Clean up the router a tad

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -78,7 +78,7 @@ const routes = [
       default: () => import('@/views/Item/ItemWrapper.vue'),
       SubNav: () => import('@/components/Navigation/ItemTabBar.vue'),
     },
-    beforeEnter: routerGuards.itemHome,
+    beforeEnter: routerGuards.itemCommon,
     children: [
       {
         path: '',
@@ -88,30 +88,32 @@ const routes = [
         path: 'okr',
         name: 'ItemHome',
         component: () => import('@/views/Item/ItemOKRs.vue'),
-        beforeEnter: routerGuards.itemHome,
       },
       {
         path: 'measurements',
         name: 'ItemMeasurements',
         component: () => import('@/views/Item/ItemMeasurements.vue'),
-        beforeEnter: routerGuards.dashboard,
+        beforeEnter: routerGuards.itemMeasurements,
+      },
+      /*
+       * Alias for `measurements` -- redirect from the old `dashboard` path
+       * still in case people have bookmarked it.
+       */
+      {
+        path: 'dashboard',
+        name: 'Dashboard',
+        redirect: { name: 'ItemMeasurements' },
       },
       {
         path: 'about',
         name: 'ItemAbout',
         component: () => import('@/views/Item/ItemAbout.vue'),
-        beforeEnter: routerGuards.itemHome,
       },
       {
         path: 'admin',
         name: 'ItemAdmin',
         component: () => import('@/views/ItemAdmin/ItemAdminWrapper.vue'),
         beforeEnter: routerGuards.itemAdmin,
-      },
-      {
-        path: 'dashboard',
-        name: 'Dashboard',
-        redirect: { name: 'ItemMeasurements' },
       },
       {
         path: 'k/:keyResultId',
@@ -125,7 +127,6 @@ const routes = [
         component: () => import('@/views/ObjectiveHome.vue'),
         beforeEnter: routerGuards.objectiveHome,
       },
-
       {
         path: 'kpi/:kpiId',
         name: 'KpiHome',

--- a/src/router/router-guards/index.js
+++ b/src/router/router-guards/index.js
@@ -1,11 +1,11 @@
-export { default as home } from './home';
-export { default as itemHome } from './itemHome';
-export { default as itemAdmin } from './itemAdmin';
-export { default as keyResultHome } from './keyResultHome';
-export { default as objectiveHome } from './objectiveHome';
 export { default as admin } from './admin';
-export { default as login } from './login';
-export { default as user } from './user';
-export { default as requestAccess } from './requestAccess'; /* eslint-disable-line */
+export { default as home } from './home';
+export { default as itemAdmin } from './itemAdmin';
+export { default as itemCommon } from './itemCommon';
+export { default as itemMeasurements } from './itemMeasurements';
+export { default as keyResultHome } from './keyResultHome';
 export { default as kpiHome } from './kpiHome';
-export { default as dashboard } from './dashboard';
+export { default as login } from './login';
+export { default as objectiveHome } from './objectiveHome';
+export { default as requestAccess } from './requestAccess';
+export { default as user } from './user';

--- a/src/router/router-guards/itemCommon.js
+++ b/src/router/router-guards/itemCommon.js
@@ -4,18 +4,12 @@ import getSlugRef from './routerGuardUtil';
 const { state } = store;
 
 /**
- * Router guard for organization, department, and product 'home' pages.
+ * Common router guard for "item" (organization, department, and product) pages
+ * and their sub-pages.
  */
-export default async function itemHome(to, from, next) {
+export default async function itemCommon(to, from, next) {
   const { activeItem } = state;
   const { slug } = to.params;
-
-  if (from.params && from.params.slug === slug) {
-    next();
-  }
-  if (activeItem && activeItem.slug === slug) {
-    next();
-  }
 
   try {
     const slugRef = await getSlugRef(slug);

--- a/src/router/router-guards/itemMeasurements.js
+++ b/src/router/router-guards/itemMeasurements.js
@@ -3,7 +3,7 @@ import getPeriods from '@/config/periods';
 
 const { state } = store;
 
-export default async function dashboard(to, from, next) {
+export default async function itemMeasurements(to, from, next) {
   const { activeItem } = state;
 
   try {

--- a/src/views/Item/ItemWrapper.vue
+++ b/src/views/Item/ItemWrapper.vue
@@ -3,7 +3,7 @@
 </template>
 
 <script>
-import { itemHome as routerGuard } from '@/router/router-guards';
+import { itemCommon as routerGuard } from '@/router/router-guards';
 
 export default {
   name: 'ItemWrapper',


### PR DESCRIPTION
Clean up the router, mainly by preventing `itemHome` (now named `itemCommon`) from running twice in some routes.

The logic in `itemHome` (now `itemCommon`) intended to prevent it from running twice was also flawed, since `next()` doesn't actually cause the function to return.