### PR TITLE
Support listing objectives without period

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -165,6 +165,24 @@
           "order": "ASCENDING"
         },
         {
+          "fieldPath": "parent",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "name",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "objectives",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "archived",
+          "order": "ASCENDING"
+        },
+        {
           "fieldPath": "period",
           "order": "ASCENDING"
         },
@@ -271,6 +289,7 @@
     {
       "collectionGroup": "departments",
       "fieldPath": "slug",
+      "ttl": false,
       "indexes": [
         {
           "order": "ASCENDING",
@@ -293,6 +312,7 @@
     {
       "collectionGroup": "keyResults",
       "fieldPath": "auto",
+      "ttl": false,
       "indexes": [
         {
           "order": "ASCENDING",
@@ -315,6 +335,7 @@
     {
       "collectionGroup": "keyResults",
       "fieldPath": "createdBy",
+      "ttl": false,
       "indexes": [
         {
           "order": "ASCENDING",
@@ -337,6 +358,7 @@
     {
       "collectionGroup": "objectives",
       "fieldPath": "createdBy",
+      "ttl": false,
       "indexes": [
         {
           "order": "ASCENDING",
@@ -359,6 +381,7 @@
     {
       "collectionGroup": "periods",
       "fieldPath": "createdBy",
+      "ttl": false,
       "indexes": [
         {
           "order": "ASCENDING",
@@ -381,6 +404,7 @@
     {
       "collectionGroup": "products",
       "fieldPath": "slug",
+      "ttl": false,
       "indexes": [
         {
           "order": "ASCENDING",
@@ -403,6 +427,7 @@
     {
       "collectionGroup": "products",
       "fieldPath": "team",
+      "ttl": false,
       "indexes": [
         {
           "order": "ASCENDING",
@@ -425,6 +450,7 @@
     {
       "collectionGroup": "progress",
       "fieldPath": "createdBy",
+      "ttl": false,
       "indexes": [
         {
           "order": "ASCENDING",

--- a/src/components/widgets/WidgetWeights.vue
+++ b/src/components/widgets/WidgetWeights.vue
@@ -18,6 +18,7 @@
 <script>
 import { scaleLinear } from 'd3-scale';
 import { max } from 'd3-array';
+import objectiveInPeriod from '@/util/okr';
 
 export default {
   name: 'WidgetWeights',
@@ -56,7 +57,7 @@ export default {
       let siblings = null;
 
       if (this.type === 'objective') {
-        siblings = ({ period }) => period.split('/')[1] === this.activeItem.id;
+        siblings = (o) => objectiveInPeriod(this.activeItem, o);
       } else {
         siblings = ({ objective }) => objective.split('/')[1] === this.activeItem.id;
       }

--- a/src/store/actions/set_active_period_and_data.js
+++ b/src/store/actions/set_active_period_and_data.js
@@ -13,10 +13,14 @@ export default firestoreAction(async ({ bindFirestoreRef, unbindFirestoreRef }, 
   const activePeriodRef = db.collection('periods').doc(id);
   await bindFirestoreRef('activePeriod', activePeriodRef, { maxRefDepth: 0 });
 
+  const parentRef = await activePeriodRef
+    .get()
+    .then((snapshot) => snapshot.data().parent);
+
   const objectivesRef = db
     .collection('objectives')
     .where('archived', '==', false)
-    .where('period', '==', activePeriodRef)
+    .where('parent', '==', parentRef)
     .orderBy('name');
 
   const activeObjectivesList = await objectivesRef
@@ -24,16 +28,13 @@ export default firestoreAction(async ({ bindFirestoreRef, unbindFirestoreRef }, 
     .then((snapshot) => snapshot.docs.map((doc) => doc.ref));
 
   if (activeObjectivesList.length) {
-    const parentRef = await activePeriodRef
-      .get()
-      .then((snapshot) => snapshot.data().parent);
     const keyResultsRef = db
       .collection('keyResults')
       .where('archived', '==', false)
       .where('parent', '==', parentRef)
       .orderBy('name');
 
-    await bindFirestoreRef('objectives', objectivesRef, { maxRefDepth: 0 });
+    await bindFirestoreRef('objectives', objectivesRef, { maxRefDepth: 1 });
     await bindFirestoreRef('keyResults', keyResultsRef, { maxRefDepth: 0 });
   } else {
     unbindFirestoreRef('objectives');

--- a/src/util/okr.js
+++ b/src/util/okr.js
@@ -1,0 +1,19 @@
+/**
+ * Return true if `objective` is in `period`.
+ *
+ * "In" doesn't mean that the objective have to be fully within the period,
+ * just that it overlaps the period with at least one day.
+ */
+export default function objectiveInPeriod(period, objective) {
+  const { startDate, endDate } = period;
+
+  if (objective.startDate && objective.endDate) {
+    return objective.endDate >= startDate && objective.startDate <= endDate;
+  }
+
+  /*
+   * Fall back to checking the old-style `period` reference to retain backwards
+   * compatibility.
+   */
+  return objective.period.endDate >= startDate && objective.period.startDate <= endDate;
+}


### PR DESCRIPTION
Support listing objectives without a `period` reference, but that rather have `startDate` and `endDate` set directly on themselves.