### PR TITLE
Check actual period reference instead of dates

### DIFF
--- a/src/util/okr.js
+++ b/src/util/okr.js
@@ -15,5 +15,5 @@ export default function objectiveInPeriod(period, objective) {
    * Fall back to checking the old-style `period` reference to retain backwards
    * compatibility.
    */
-  return objective.period.endDate >= startDate && objective.period.startDate <= endDate;
+  return objective.period.id === period.id;
 }


### PR DESCRIPTION
The previous check didn't hold when periods overlap; objectives could then be deemed to belong to multiple periods.