### PR TITLE
Declare Firebase functions codebase

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -41,6 +41,7 @@
     }
   },
   "functions": {
+    "codebase": "okr-tracker",
     "source": "functions"
   }
 }


### PR DESCRIPTION
Declare a codebase in the Firebase functions config. This makes it possible to have functions spread across different codebases deploy to the same Firebase project without deleting all the unknown functions.