### PR TITLE
Bump the OpenAPI spec version

### DIFF
--- a/public/openapi.yaml
+++ b/public/openapi.yaml
@@ -3,7 +3,7 @@ swagger: "2.0"
 info:
   title: OKR Tracker API
   description: API for updating KPIs and key results.
-  version: 1.4.0
+  version: 1.5.0
   contact:
     name: Dataspeilet
     url: https://okr.oslo.systems


### PR DESCRIPTION
This should have been done in 63d8bad8be8449c7656d7dc1d1c87633874e0304, but was forgotten.