### PR TITLE
Align Gantt chart design better

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ All notable changes to this project will be documented in this file. The format 
 - A new timeline view for objectives has been added (visualized in a Gantt
   chart).
 
+### Changed
+
+- Improved OKR overview page styling.
+
 ### Fixed
 
 - Fixed rendering of charts containing goals with missing value.

--- a/src/components/GanttChart.vue
+++ b/src/components/GanttChart.vue
@@ -236,6 +236,6 @@ export default {
 .objective {
   position: relative;
   z-index: 1;
-  margin: 1.25rem 0;
+  margin: 1rem 0;
 }
 </style>

--- a/src/components/GanttChart.vue
+++ b/src/components/GanttChart.vue
@@ -23,17 +23,14 @@
         <span class="ticks__padding"></span>
       </div>
     </div>
-    <router-link
+    <objective-row
       v-for="o in orderedObjectives"
       :key="o.id"
-      :to="{ name: 'ObjectiveHome', params: { objectiveId: o.id } }"
-      class="objective"
+      :objective="o"
+      :show-progress="true"
       :style="objectiveStyle(o)"
     >
-      <div class="objective__tag">{{ item.name }}</div>
-      <div class="objective__title">{{ o.name }}</div>
-      <progress-bar :progression="o.progression * 100" />
-    </router-link>
+    </objective-row>
     <div class="today-tick" :style="todayStyle()"></div>
   </div>
 </template>
@@ -54,7 +51,7 @@ export default {
   name: 'GanttChart',
 
   components: {
-    ProgressBar: () => import('@/components/ProgressBar.vue'),
+    ObjectiveRow: () => import('@/components/ObjectiveRow.vue'),
   },
 
   props: {
@@ -239,35 +236,6 @@ export default {
 .objective {
   position: relative;
   z-index: 1;
-  display: block;
   margin: 1.25rem 0;
-  padding: 1rem;
-  color: var(--color-text);
-  line-height: 1.35;
-  text-decoration: none;
-  background: var(--color-white);
-  box-shadow: 0 0 10px rgba(black, 0.1);
-  cursor: pointer;
-
-  &:hover .objective__title {
-    color: var(--color-hover);
-  }
-
-  .objective__tag {
-    display: inline-block;
-    padding: 0.5rem;
-    background: var(--color-blue-5);
-  }
-
-  .objective__title {
-    max-width: 35rem;
-    margin: 1.25rem 0;
-    font-weight: 500;
-  }
-
-  label {
-    display: block;
-    cursor: pointer;
-  }
 }
 </style>

--- a/src/components/ObjectiveRow.vue
+++ b/src/components/ObjectiveRow.vue
@@ -60,10 +60,14 @@ export default {
   grid-template-rows: auto auto;
   grid-template-columns: 1fr;
   align-items: center;
-  padding: 2.5rem 2rem 2rem 2rem;
+  padding: 1.5rem 1.5rem 1.25rem 1.5rem;
   color: var(--color-text);
   text-decoration: none;
   background: var(--color-white);
+
+  .title-2 {
+    line-height: 1.25;
+  }
 
   &:hover {
     color: var(--color-hover);
@@ -76,6 +80,7 @@ export default {
 
 .objective__header {
   display: flex;
+  gap: 1.5rem;
   justify-content: space-between;
   margin-bottom: 0;
 }
@@ -86,6 +91,6 @@ export default {
 }
 
 .objective__spacer {
-  height: 1.5rem;
+  height: 0.5rem;
 }
 </style>

--- a/src/components/ObjectiveRow.vue
+++ b/src/components/ObjectiveRow.vue
@@ -7,9 +7,11 @@
       <span>{{ objective.name }}</span>
       <span>{{ percent(objective.progression) }}</span>
     </h3>
-    <p v-if="objective.description" class="objective__description">
+    <p v-if="showDescription && objective.description" class="objective__description">
       {{ objective.description }}
     </p>
+    <div v-if="showProgress" class="objective__spacer"></div>
+    <progress-bar v-if="showProgress" :progression="objective.progression * 100" />
   </router-link>
 </template>
 
@@ -20,10 +22,22 @@ import { format } from 'd3-format';
 export default {
   name: 'ObjectiveRow',
 
+  components: {
+    ProgressBar: () => import('@/components/ProgressBar.vue'),
+  },
+
   props: {
     objective: {
       type: Object,
       required: true,
+    },
+    showDescription: {
+      type: Boolean,
+      default: false,
+    },
+    showProgress: {
+      type: Boolean,
+      default: false,
     },
   },
 
@@ -49,6 +63,7 @@ export default {
   padding: 2.5rem 2rem 2rem 2rem;
   color: var(--color-text);
   text-decoration: none;
+  background: var(--color-white);
 
   &:hover {
     color: var(--color-hover);
@@ -68,5 +83,9 @@ export default {
 .objective__description {
   margin-top: 0.25rem;
   line-height: 1.5rem;
+}
+
+.objective__spacer {
+  height: 1.5rem;
 }
 </style>

--- a/src/views/Item/ItemOKRs.vue
+++ b/src/views/Item/ItemOKRs.vue
@@ -42,7 +42,8 @@
                 :key="objective.id"
                 class="itemHome__objectives--item"
               >
-                <objective-row :objective="objective"></objective-row>
+                <objective-row :objective="objective" :show-description="true">
+                </objective-row>
                 <ul v-if="objective.keyResults.length">
                   <li
                     v-for="keyResult in objective.keyResults"


### PR DESCRIPTION
Align the Gantt chart design better by aligning the objective boxes with the compact and detailed views by reusing the `ObjectiveRow` component.

The team tag is removed for now, since it only causes noise as long as goals belong to only one team at the time.