### PR TITLE
Move copy button inside copiable input control

### DIFF
--- a/src/components/FormComponent.vue
+++ b/src/components/FormComponent.vue
@@ -17,7 +17,9 @@
         <slot name="help"></slot>
       </div>
 
-      <div class="form-input__wrapper">
+      <div
+        :class="['form-input__wrapper', { 'form-input__wrapper--copiable': copyButton }]"
+      >
         <input
           v-if="inputType === 'input'"
           :id="name"
@@ -83,10 +85,10 @@
         <button
           v-if="copyButton"
           v-tooltip="$t('tooltip.copyToClipboard')"
-          class="btn btn--sec"
+          class="pkt-btn pkt-btn--tertiary pkt-btn--icon-only form-input__copy-button"
           @click="copyFieldText"
         >
-          <i class="form-input__copy-button far fa-clone" />
+          <pkt-icon class="pkt-btn__icon" name="copy" />
         </button>
       </div>
 

--- a/src/styles/_forms.scss
+++ b/src/styles/_forms.scss
@@ -144,10 +144,10 @@
   }
 
   &__copy-button {
-    position: absolute !important;
+    position: absolute;
     top: 2px;
     right: 2px;
-    height: 2.875rem !important;
+    height: 2.875rem;
   }
 }
 

--- a/src/styles/_forms.scss
+++ b/src/styles/_forms.scss
@@ -122,14 +122,32 @@
   }
 }
 
-.form-input__wrapper {
-  display: flex;
-  align-items: stretch;
-  justify-content: space-between;
+.form-input {
+  &__wrapper {
+    display: flex;
+    align-items: stretch;
+    justify-content: space-between;
 
-  > .flatpickr-wrapper {
-    display: block;
-    width: 100%;
+    > .flatpickr-wrapper {
+      display: block;
+      width: 100%;
+    }
+
+    &--copiable {
+      position: relative;
+
+      .pkt-form-input,
+      .pkt-form-textarea {
+        padding-right: 3rem;
+      }
+    }
+  }
+
+  &__copy-button {
+    position: absolute !important;
+    top: 2px;
+    right: 2px;
+    height: 2.875rem !important;
   }
 }
 


### PR DESCRIPTION
The button is now also styled by Punkt. ~~Depends on https://github.com/oslokommune/okr-tracker/pull/701~~.
<img width="728" alt="image" src="https://user-images.githubusercontent.com/2866225/233062508-c90b9ea7-12fb-4288-b084-c3804b54be11.png">