### PR TITLE
Support adjustable measurement y-axis start values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ All notable changes to this project will be documented in this file. The format 
 - Improved OKR overview page styling.
 - Improved tooltip styling.
 - All forms now use Punkt-styled input fields.
+- Y-axes in measurement graphs now start counting from zero by default. It's
+  possible to revert individual measurements to the old behavior of starting the
+  y-axis around the lowest measured value in the measurement admin settings.
 
 ### Fixed
 

--- a/src/components/forms/KpiAdminForm.vue
+++ b/src/components/forms/KpiAdminForm.vue
@@ -23,15 +23,26 @@
         :label="$t('fields.description')"
       />
 
-      <div class="form-row">
+      <div class="display-settings">
         <form-component
           v-model="localKpi.format"
           input-type="select"
           name="format"
-          :label="$t('kpi.display')"
+          :label="$t('kpi.format')"
           rules="required"
           select-label="label"
           :select-options="formats"
+          :select-reduce="(option) => option.id"
+          type="text"
+        />
+        <form-component
+          v-model="localKpi.startValue"
+          input-type="select"
+          name="startValue"
+          :label="$t('kpi.startValue')"
+          rules="required"
+          select-label="label"
+          :select-options="startValues"
           :select-reduce="(option) => option.id"
           type="text"
         />
@@ -161,6 +172,7 @@
 import { functions } from '@/config/firebaseConfig';
 import {
   kpiFormats,
+  kpiStartValues,
   kpiTypes,
   kpiTrendOptions,
   kpiUpdateFrequencies,
@@ -201,6 +213,7 @@ export default {
   data: () => ({
     localKpi: null,
     formats: kpiFormats(),
+    startValues: kpiStartValues(),
     trendOptions: kpiTrendOptions(),
     types: kpiTypes(),
     updateFrequencies: kpiUpdateFrequencies(),
@@ -220,6 +233,7 @@ export default {
       sheetId,
       sheetName,
       sheetUrl,
+      startValue,
       updateFrequency,
     } = this.kpi;
 
@@ -237,6 +251,7 @@ export default {
       sheetCell,
       sheetName,
       sheetUrl: sheetUrl || '',
+      startValue,
       updateFrequency,
     };
   },
@@ -283,13 +298,30 @@ export default {
     }
   }
 }
-::v-deep .form-row {
-  display: flex;
-  flex-direction: column;
-  align-items: stretch;
 
-  > span {
-    flex: 1;
+::v-deep .display-settings {
+  display: grid;
+  grid-column-gap: 0.5rem;
+  grid-template-columns: repeat(2, 1fr);
+
+  > * {
+    grid-column: 1 / 3;
+
+    @media screen and (min-width: bp(s)) {
+      grid-column: unset;
+
+      .pkt-form-group {
+        margin-bottom: 0;
+      }
+    }
+  }
+
+  > *:last-child {
+    grid-column: 1 / 3;
+
+    .pkt-form-group {
+      margin-bottom: 1.5rem;
+    }
   }
 
   @media screen and (min-width: bp(s)) {

--- a/src/components/widgets/WidgetKpiCard/MiniGraph.vue
+++ b/src/components/widgets/WidgetKpiCard/MiniGraph.vue
@@ -18,7 +18,7 @@
 import { scaleTime, scaleLinear } from 'd3-scale';
 import { area, line, curveLinear } from 'd3-shape';
 import { axisBottom, axisLeft } from 'd3-axis';
-import { extent, max } from 'd3-array';
+import { extent, max, min } from 'd3-array';
 
 export default {
   name: 'MiniGraph',
@@ -28,6 +28,11 @@ export default {
       type: Array,
       required: false,
       default: () => [],
+    },
+    startValue: {
+      type: String,
+      required: false,
+      default: 'zero',
     },
   },
   data() {
@@ -76,7 +81,7 @@ export default {
         .rangeRound([0, this.chartDefaults.width]);
       const y = scaleLinear()
         .domain([
-          0,
+          this.startValue === 'min' ? min(this.data, (d) => d.count) : 0,
           max(this.data, function (d) {
             return d.count < 1 ? 1 : d.count;
           }),

--- a/src/components/widgets/WidgetKpiCard/WidgetKpiCard.vue
+++ b/src/components/widgets/WidgetKpiCard/WidgetKpiCard.vue
@@ -17,7 +17,11 @@
             :latest-progress-record="latestProgressRecord"
           />
           <div class="kpi-card-widget__graph">
-            <mini-graph v-if="progress.length > 1" :kpi-data="progress" />
+            <mini-graph
+              v-if="progress.length > 1"
+              :kpi-data="progress"
+              :start-value="kpi.startValue"
+            />
             <span v-else>{{ $t('kpi.noGraph') }}</span>
           </div>
         </template>

--- a/src/components/widgets/WidgetKpiProgressGraph.vue
+++ b/src/components/widgets/WidgetKpiProgressGraph.vue
@@ -29,7 +29,6 @@ import { csvFormatBody, csvFormatRow } from 'd3-dsv';
 import firebase from 'firebase/app';
 import { PktIcon } from '@oslokommune/punkt-vue2';
 import { periodDates } from '@/util';
-import { kpiInterval } from '@/util/kpiHelpers';
 import downloadFile from '@/util/downloadFile';
 import downloadPng from '@/util/downloadPng';
 import LineChart from '@/util/LineChart';
@@ -128,7 +127,6 @@ export default {
       this.setStartAndEndDates();
 
       const kpi = this.kpi;
-      const [startValue, targetValue] = kpiInterval(kpi.format);
 
       this.graph.render({
         startDate: this.startDate,
@@ -143,8 +141,8 @@ export default {
           }))
           .filter((g) => g.endDate >= this.startDate && g.startDate <= this.endDate),
         kpi,
-        startValue,
-        targetValue,
+        startValue: kpi.startValue === 'min' ? null : 0,
+        targetValue: kpi.format === 'percentage' ? 1 : null,
       });
     },
 

--- a/src/locale/locales/en-US.json
+++ b/src/locale/locales/en-US.json
@@ -18,7 +18,8 @@
     "newValue": "New value",
     "editValue": "Edit value",
     "description": "Description",
-    "display": "Display",
+    "format": "Format",
+    "startValue": "Start value for display",
     "preferredTrend": "Trend",
     "inPeriod": "in period",
     "noChange": "no change",
@@ -29,6 +30,10 @@
     "formats": {
       "integer": "Integer",
       "percentage": "Percentage"
+    },
+    "startValues": {
+      "zero": "Zero",
+      "min": "Lowest measured value"
     },
     "trendOptions": {
       "increase": "Increasing (high numbers preferred)",

--- a/src/locale/locales/nb-NO.json
+++ b/src/locale/locales/nb-NO.json
@@ -18,7 +18,8 @@
     "newValue": "Legg til målepunkt",
     "editValue": "Endre målepunkt",
     "description": "Beskrivelse",
-    "display": "Visning",
+    "format": "Format",
+    "startValue": "Startverdi ved visning",
     "preferredTrend": "Ønsket trend",
     "inPeriod": "i perioden",
     "noChange": "ingen endring",
@@ -29,6 +30,10 @@
     "formats": {
       "integer": "Heltall",
       "percentage": "Prosent"
+    },
+    "startValues": {
+      "zero": "Null",
+      "min": "Lavest målte verdi"
     },
     "trendOptions": {
       "increase": "Stigende (høyt tall er bra)",

--- a/src/util/kpiHelpers.js
+++ b/src/util/kpiHelpers.js
@@ -19,6 +19,22 @@ export function kpiFormats() {
 }
 
 /**
+ * Return a list of available KPI start value display options.
+ */
+export function kpiStartValues() {
+  return [
+    {
+      id: 'zero',
+      label: i18n.t('kpi.startValues.zero'),
+    },
+    {
+      id: 'min',
+      label: i18n.t('kpi.startValues.min'),
+    },
+  ];
+}
+
+/**
  * Return a list of available KPI expected trend options.
  */
 export function kpiTrendOptions() {
@@ -126,16 +142,6 @@ export function formatKPIValue(kpi, value = null, options = {}) {
   }
 
   return '–––';
-}
-
-/**
- * Return an appropriate value interval for a given KPI format type.
- */
-export function kpiInterval(formatId) {
-  if (formatId === 'percentage') {
-    return [0, 1];
-  }
-  return [null, null];
 }
 
 /**

--- a/src/views/ItemAdmin/ItemAdminKPIs.vue
+++ b/src/views/ItemAdmin/ItemAdminKPIs.vue
@@ -90,6 +90,7 @@ export default {
         name: this.$t('kpi.placeholderName'),
         description: '',
         format: 'integer',
+        startValue: 'zero',
         preferredTrend: 'increase',
         kpiType: 'plain',
         updateFrequency: 'daily',


### PR DESCRIPTION
Start y-axes in measurement graphs counting from zero by default. Make it possible to revert individual measurements to the old behavior of starting the y-axis around the lowest measured value in the measurement admin settings.