### PR TITLE
Fix display of KRs for periodless objectives

### DIFF
--- a/src/components/widgets/WidgetKeyResultDetails.vue
+++ b/src/components/widgets/WidgetKeyResultDetails.vue
@@ -17,11 +17,11 @@
         </div>
       </div>
 
-      <div v-if="activePeriod && activePeriod.startDate" class="details__item">
+      <div v-if="formattedPeriod(activeKeyResult.objective)" class="details__item">
         <h3 class="title-3 details__item-heading">{{ $t('objective.period') }}</h3>
         <div class="details__item-body">
           <div class="details__item-value">
-            {{ activePeriod.name }} ({{ formatPeriodDates(activePeriod) }})
+            {{ formattedPeriod(activeKeyResult.objective) }}
           </div>
         </div>
       </div>
@@ -109,7 +109,8 @@
 <script>
 import { mapState } from 'vuex';
 import { db } from '@/config/firebaseConfig';
-import { periodDates, dateShort, dateLong } from '@/util';
+import { dateLong } from '@/util';
+import { formattedPeriod } from '@/util/okr';
 
 export default {
   name: 'WidgetKeyResultDetails',
@@ -126,7 +127,7 @@ export default {
   }),
 
   computed: {
-    ...mapState(['activeKeyResult', 'activePeriod']),
+    ...mapState(['activeKeyResult']),
     createdBy() {
       return (
         this.activeKeyResult.createdBy.displayName || this.activeKeyResult.createdBy.id
@@ -155,9 +156,7 @@ export default {
   },
 
   methods: {
-    formatPeriodDates(period) {
-      return periodDates(period, dateShort);
-    },
+    formattedPeriod,
 
     formatDate(date) {
       return dateLong(date.toDate());

--- a/src/components/widgets/WidgetObjectiveDetails.vue
+++ b/src/components/widgets/WidgetObjectiveDetails.vue
@@ -1,16 +1,11 @@
 <template>
   <widget v-if="activeObjective" :title="$t('general.details')" size="small">
     <div class="details">
-      <div
-        v-if="activeObjective.period && activeObjective.period.startDate"
-        class="details__item"
-      >
+      <div v-if="formattedPeriod(activeObjective)" class="details__item">
         <h3 class="title-3 details__item-heading">{{ $t('objective.period') }}</h3>
         <div class="details__item-body">
           <div class="details__item-value">
-            {{ activeObjective.period.name }} ({{
-              formatPeriodDates(activeObjective.period)
-            }})
+            {{ formattedPeriod(activeObjective) }}
           </div>
         </div>
       </div>
@@ -74,7 +69,8 @@
 
 <script>
 import { mapState } from 'vuex';
-import { periodDates, dateShort, dateLong } from '@/util';
+import { dateLong } from '@/util';
+import { formattedPeriod } from '@/util/okr';
 
 export default {
   name: 'WidgetObjectiveDetails',
@@ -104,9 +100,7 @@ export default {
   },
 
   methods: {
-    formatPeriodDates(period) {
-      return periodDates(period, dateShort);
-    },
+    formattedPeriod,
 
     formatDate(date) {
       return dateLong(date.toDate());

--- a/src/router/router-guards/keyResultHome.js
+++ b/src/router/router-guards/keyResultHome.js
@@ -1,17 +1,10 @@
 import store from '@/store';
-import { documentIdFromRef } from '@/util/firebaseUtil';
 
 export default async function keyResultHome(to, from, next) {
   const { keyResultId } = to.params;
 
   try {
-    const { objective } = await store.dispatch('set_active_key_result', keyResultId);
-    const objectivePeriodId = documentIdFromRef(objective.period);
-    const { activePeriod } = store.state;
-
-    if (!activePeriod || activePeriod.id !== objectivePeriodId) {
-      await store.dispatch('set_active_period_and_data', objectivePeriodId);
-    }
+    await store.dispatch('set_active_key_result', keyResultId);
     next();
   } catch (error) {
     console.error(error);

--- a/src/store/actions/set_active_key_result.js
+++ b/src/store/actions/set_active_key_result.js
@@ -14,6 +14,6 @@ export default firestoreAction(
       await bindFirestoreRef('activeObjective', objective, { maxRefDepth: 1 });
     }
 
-    return bindFirestoreRef('activeKeyResult', reference, { maxRefDepth: 1 });
+    return bindFirestoreRef('activeKeyResult', reference, { maxRefDepth: 2 });
   }
 );

--- a/src/util/format.js
+++ b/src/util/format.js
@@ -17,7 +17,7 @@ export function periodDates({ startDate, endDate }, strategy = dateLong) {
     endDate instanceof Date ? endDate : endDate.toDate(),
   ]
     .map(strategy)
-    .join(' – ');
+    .join('​–​');
 }
 
 export const parseDate = (d) => parseISO(d);

--- a/src/util/okr.js
+++ b/src/util/okr.js
@@ -1,10 +1,12 @@
+import { dateShort, periodDates } from '@/util';
+
 /**
  * Return true if `objective` is in `period`.
  *
  * "In" doesn't mean that the objective have to be fully within the period,
  * just that it overlaps the period with at least one day.
  */
-export default function objectiveInPeriod(period, objective) {
+export function objectiveInPeriod(period, objective) {
   const { startDate, endDate } = period;
 
   if (objective.startDate && objective.endDate) {
@@ -16,4 +18,20 @@ export default function objectiveInPeriod(period, objective) {
    * compatibility.
    */
   return objective.period.id === period.id;
+}
+
+/**
+ * Return a nicely formatted period range for `objective`'s period.
+ */
+export function formattedPeriod(objective) {
+  const { period, startDate, endDate } = objective;
+
+  if (startDate && endDate) {
+    return periodDates({ startDate, endDate }, dateShort);
+  }
+  if (period) {
+    return `${period.name} (${periodDates(period, dateShort)})`;
+  }
+
+  return null;
 }

--- a/src/views/Item/ItemOKRs.vue
+++ b/src/views/Item/ItemOKRs.vue
@@ -80,7 +80,7 @@
 <script>
 import { mapGetters, mapState, mapActions } from 'vuex';
 import { isBefore, addDays, isWithinInterval } from 'date-fns';
-import objectiveInPeriod from '@/util/okr';
+import { objectiveInPeriod } from '@/util/okr';
 import { periodDates } from '@/util';
 import ContentLoaderItem from '@/components/ContentLoader/ContentLoaderItem.vue';
 import ContentLoaderActionBar from '@/components/ContentLoader/ContentLoaderActionBar.vue';


### PR DESCRIPTION
Fix the key result page when the key result belongs to an objective without a period reference.

Also show the period on the detail pages for objectives without period references, just like we do for those with periods.
