### PR TITLE
Use zero as start value for existing measurements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [UNRELEASED]
 
+### Changed
+
+- The option of where to start measurement y-axes has been set to zero by
+  default for existing measurements too.
+
 ### Fixed
 
 - Fixed a bug that made pressing Enter on the access request page clear the form

--- a/src/components/forms/KpiAdminForm.vue
+++ b/src/components/forms/KpiAdminForm.vue
@@ -251,7 +251,7 @@ export default {
       sheetCell,
       sheetName,
       sheetUrl: sheetUrl || '',
-      startValue,
+      startValue: startValue || 'zero',
       updateFrequency,
     };
   },


### PR DESCRIPTION
Use zero as the default start value for existing measurements in addition to new ones.