### PR TITLE
Don't clear request access form on Enter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [UNRELEASED]
 
+### Fixed
+
+- Fixed a bug that made pressing Enter on the access request page clear the form
+  instead of submitting it.
+
 ## [3.6.0] 2023-05-05
 
 ### Added

--- a/src/views/RequestAccess.vue
+++ b/src/views/RequestAccess.vue
@@ -20,7 +20,7 @@
         />
 
         <template #actions="{ handleSubmit, submitDisabled }">
-          <btn
+          <btn-save
             :disabled="submitDisabled || loading"
             :label="$t('login.requestButton')"
             @click="handleSubmit(send)"
@@ -35,14 +35,14 @@
 import { mapMutations } from 'vuex';
 import api from '@/util/api';
 import { showToastMessage } from '@/util/toastUtils';
-import { FormSection, Btn } from '@/components/generic/form';
+import { FormSection, BtnSave } from '@/components/generic/form';
 
 export default {
   name: 'RequestAccess',
 
   components: {
     FormSection,
-    Btn,
+    BtnSave,
   },
 
   data: () => ({

--- a/src/views/RequestAccess.vue
+++ b/src/views/RequestAccess.vue
@@ -23,6 +23,7 @@
           <btn-save
             :disabled="submitDisabled || loading"
             :label="$t('login.requestButton')"
+            :icon="null"
             @click="handleSubmit(send)"
           />
         </template>


### PR DESCRIPTION
Fix a bug that makes pressing Enter on the access request page clear the form instead of submitting it.