### PR TITLE
Unstick the header bars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file. The format 
 
 - Fixed a bug that made pressing Enter on the access request page clear the form
   instead of submitting it.
+- Fixed anchor link positioning.
 
 ## [3.6.0] 2023-05-05
 

--- a/src/components/AppLayout.vue
+++ b/src/components/AppLayout.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div class="app-wrapper">
     <site-header
       :toggle-show-aside-left="toggleShowAsideLeft"
       :toggle-show-aside-right="toggleShowAsideRight"
@@ -22,7 +22,9 @@
       <user-profile-menu :id="user.id" />
     </slider-container>
     <v-spinner v-if="loading" />
-    <router-view v-else></router-view>
+    <div v-else class="router-view-wrapper">
+      <router-view></router-view>
+    </div>
   </div>
 </template>
 
@@ -64,3 +66,15 @@ export default {
   },
 };
 </script>
+
+<style lang="scss" scoped>
+.app-wrapper {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+}
+
+.router-view-wrapper {
+  overflow-y: scroll;
+}
+</style>

--- a/src/components/Navigation/ItemTabBar.vue
+++ b/src/components/Navigation/ItemTabBar.vue
@@ -181,9 +181,6 @@ export default {
 
 <style lang="scss" scoped>
 .sub-navigation {
-  position: sticky;
-  top: 4rem;
-  z-index: 20;
   display: flex;
   background-color: var(--color-white);
   border-bottom: 1px solid var(--color-grayscale-10);

--- a/src/components/Navigation/SiteHeader.vue
+++ b/src/components/Navigation/SiteHeader.vue
@@ -77,13 +77,10 @@ export default {
 
 <style lang="scss" scoped>
 .site-header {
-  position: sticky;
-  top: 0;
-  z-index: 20;
   display: flex;
+  flex: 0 0 4rem;
   align-items: center;
   justify-content: space-between;
-  height: 4rem;
   padding: 0 0.6875rem;
   color: var(--color-text-secondary);
   background: var(--color-primary);

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -48,10 +48,6 @@ body {
   -moz-osx-font-smoothing: grayscale;
 }
 
-html {
-  overflow-y: scroll;
-}
-
 *,
 *::before,
 *::after {

--- a/src/views/ItemAdmin/ItemAdminKPI.vue
+++ b/src/views/ItemAdmin/ItemAdminKPI.vue
@@ -1,5 +1,6 @@
 <template>
   <collapse-container
+    :id="kpi.id"
     :visible="visible"
     :class="[
       'form-card',
@@ -10,7 +11,6 @@
   >
     <template #collapse-header>
       <div class="kpi__header">
-        <a :id="`${kpi.id}`" class="anchor" />
         <span class="kpi__header-label">{{ typeLabel }}</span>
         <h2>{{ kpi.name }}</h2>
       </div>
@@ -242,15 +242,6 @@ export default {
 
 .kpi__header {
   flex-grow: 1;
-
-  > a.anchor {
-    // Position the anchor with an offset to account
-    // for the fixed site header.
-    position: relative;
-    top: -12rem;
-    display: block;
-    visibility: hidden;
-  }
 
   > h2 {
     font-weight: 500;

--- a/src/views/ItemAdmin/ItemAdminKPIs.vue
+++ b/src/views/ItemAdmin/ItemAdminKPIs.vue
@@ -119,8 +119,13 @@ export default {
       this.$nextTick(() => {
         const kpiEl = document.getElementById(kpiId);
         if (kpiEl) {
-          const bounds = kpiEl.getBoundingClientRect();
-          window.scrollTo({ top: bounds.top, behavior: 'smooth' });
+          const wrapperEl = document.querySelector('.router-view-wrapper');
+          const kpiElBounds = kpiEl.getBoundingClientRect();
+          const wrapperElBounds = wrapperEl.getBoundingClientRect();
+          wrapperEl.scrollTo({
+            top: kpiElBounds.top - wrapperElBounds.top,
+            behavior: 'smooth',
+          });
         }
       });
     },


### PR DESCRIPTION
Don't use `position: sticky` for the main header bars as it messes with scroll position handling. It also makes the scroll bar overlap the headers.

Depends on ~~https://github.com/oslokommune/okr-tracker/pull/716~~.