### PR TITLE
Support key results on higher level objectives

### DIFF
--- a/src/router/router-guards/objectiveHome.js
+++ b/src/router/router-guards/objectiveHome.js
@@ -4,12 +4,8 @@ export default async function objectiveHome(to, from, next) {
   const { objectiveId } = to.params;
 
   try {
-    const { period } = await store.dispatch('set_active_objective', objectiveId);
-    const { activePeriod } = store.state;
-
-    if (period && (!activePeriod || activePeriod.id !== period.id)) {
-      await store.dispatch('set_active_period_and_data', period.id);
-    }
+    await store.dispatch('set_active_objective', objectiveId);
+    await store.dispatch('set_key_results', objectiveId);
     next();
   } catch (error) {
     console.error(error);

--- a/src/store/actions/index.js
+++ b/src/store/actions/index.js
@@ -6,6 +6,7 @@ import set_active_key_result from './set_active_key_result';
 import set_active_kpi from './set_active_kpi';
 import set_active_objective from './set_active_objective';
 import set_active_period_and_data from './set_active_period_and_data';
+import set_key_results from './set_key_results';
 import set_sub_kpis from './set_sub_kpis.js';
 import set_user from './set_user';
 import update_preferences from './update_preferences';
@@ -18,6 +19,7 @@ export default {
   set_active_kpi,
   set_active_objective,
   set_active_period_and_data,
+  set_key_results,
   set_sub_kpis,
   set_user,
   update_preferences,

--- a/src/store/actions/set_active_period_and_data.js
+++ b/src/store/actions/set_active_period_and_data.js
@@ -5,7 +5,7 @@ export default firestoreAction(async ({ bindFirestoreRef, unbindFirestoreRef }, 
   if (!id) {
     unbindFirestoreRef('periods');
     unbindFirestoreRef('objectives');
-    unbindFirestoreRef('keyResults');
+    unbindFirestoreRef('ownKeyResults');
     unbindFirestoreRef('activePeriod');
     return false;
   }
@@ -28,18 +28,18 @@ export default firestoreAction(async ({ bindFirestoreRef, unbindFirestoreRef }, 
     .then((snapshot) => snapshot.docs.map((doc) => doc.ref));
 
   if (activeObjectivesList.length) {
-    const keyResultsRef = db
-      .collection('keyResults')
-      .where('archived', '==', false)
-      .where('parent', '==', parentRef)
-      .orderBy('name');
-
     await bindFirestoreRef('objectives', objectivesRef, { maxRefDepth: 1 });
-    await bindFirestoreRef('keyResults', keyResultsRef, { maxRefDepth: 0 });
   } else {
     unbindFirestoreRef('objectives');
-    unbindFirestoreRef('keyResults');
   }
+
+  const keyResultsRef = db
+    .collection('keyResults')
+    .where('archived', '==', false)
+    .where('parent', '==', parentRef)
+    .orderBy('name');
+
+  await bindFirestoreRef('ownKeyResults', keyResultsRef, { maxRefDepth: 0 });
 
   return true;
 });

--- a/src/store/actions/set_key_results.js
+++ b/src/store/actions/set_key_results.js
@@ -1,0 +1,16 @@
+import { firestoreAction } from 'vuexfire';
+import { db } from '@/config/firebaseConfig';
+
+export default firestoreAction(async ({ bindFirestoreRef }, objectiveId) => {
+  const objectiveRef = await db.collection('objectives').doc(objectiveId);
+
+  const keyResultsRef = db
+    .collection('keyResults')
+    .where('archived', '==', false)
+    .where('objective', '==', objectiveRef)
+    .orderBy('name');
+
+  await bindFirestoreRef('keyResults', keyResultsRef, { maxRefDepth: 0 });
+
+  return true;
+});

--- a/src/views/ObjectiveHome.vue
+++ b/src/views/ObjectiveHome.vue
@@ -11,7 +11,7 @@
 
       <section>
         <empty-state
-          v-if="!keyRes.length"
+          v-if="!keyResults.length"
           :icon="'poop'"
           :heading="$t('empty.noKeyResults.heading')"
           :body="$t('empty.noKeyResults.body')"
@@ -26,7 +26,7 @@
 
         <div class="key-results__list">
           <key-result-row
-            v-for="keyResult in keyRes"
+            v-for="keyResult in keyResults"
             :key="keyResult.id"
             :key-result="keyResult"
             :force-expanded="true"
@@ -85,10 +85,6 @@ export default {
       next(false);
     }
   },
-
-  data: () => ({
-    keyRes: [],
-  }),
 
   computed: {
     ...mapState(['activeObjective', 'keyResults']),


### PR DESCRIPTION
Support showing key results that belong to objectives on a higher level than the level of the key result itself. Also support the reverse relationship of showing key results that belong to a lower level than the objective being viewed.

Depends on ~~https://github.com/oslokommune/okr-tracker/pull/710~~.