### PR TITLE
Remove measurement target values special treatment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to this project will be documented in this file. The format 
 ### Changed
 
 - All buttons are now Punkt-styled.
+- Graphs for percentage measurements are no longer locked to 100% on the y-axis
+  by default.
 
 ## [3.7.0] 2023-06-06
 

--- a/src/components/widgets/WidgetKpiCard/MiniGraph.vue
+++ b/src/components/widgets/WidgetKpiCard/MiniGraph.vue
@@ -88,9 +88,7 @@ export default {
       const y = scaleLinear()
         .domain([
           this.startValue === 'min' ? min(this.data, (d) => d.count) : 0,
-          max(this.data, function (d) {
-            return d.count < 1 ? 1 : d.count;
-          }),
+          max(this.data, (d) => d.count),
         ])
         .range([this.chartDefaults.height, 0]);
       axisBottom().scale(x);

--- a/src/components/widgets/WidgetKpiProgressGraph.vue
+++ b/src/components/widgets/WidgetKpiProgressGraph.vue
@@ -148,7 +148,6 @@ export default {
           .filter((g) => g.endDate >= this.startDate && g.startDate <= this.endDate),
         kpi,
         startValue: kpi.startValue === 'min' ? null : 0,
-        targetValue: kpi.format === 'percentage' ? 1 : null,
       });
     },
 


### PR DESCRIPTION
The lock on 100% on the y-axis for measurements made it difficult to see changes in measurements that use a small part of the scale.

Percentage measurements that use the full part of the scale are displayed like before.