### PR TITLE
Fix event handling for nav menu toggle icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ All notable changes to this project will be documented in this file. The format 
 - Fixed the CSV download function for measurement data (regression introduced in
   version 3.5.0).
 - Fixed misleading percentage change numbers.
+- Fixed a bug causing dropdown toggles in the navigation bar not firing.
 
 ### Security
 

--- a/src/components/Navigation/navbar/NavMenuItem.vue
+++ b/src/components/Navigation/navbar/NavMenuItem.vue
@@ -36,7 +36,7 @@
           { 'nav-menu-item__inner--active': active || isOpen },
         ]"
         tabindex="0"
-        @click="activate"
+        @click.stop="activate"
         @keyup.enter="activate"
       >
         <slot name="text">


### PR DESCRIPTION
Not really sure what is going on here, other than something messing up event handling when dynamically updating the `name` prop on the `PktIcon` component (which watches this prop and uses `v-html`). The event itself seems to be captured by `@click`, but the template is not updating. Not even sure how [preventing propagation](https://v2.vuejs.org/v2/guide/events.html#Event-Modifiers) on the parent is a workaround 🤷 