### PR TITLE
Fix (another) navbar event bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ All notable changes to this project will be documented in this file. The format 
   by default.
 - The main navigation menu icon has been replaced by a more generic one.
 
+### Fixed
+
+- Fixed a bug causing dropdown toggles in the navigation bar not working.
+
 ## [3.7.0] 2023-06-06
 
 ### Added
@@ -49,7 +53,6 @@ All notable changes to this project will be documented in this file. The format 
 - Fixed the CSV download function for measurement data (regression introduced in
   version 3.5.0).
 - Fixed misleading percentage change numbers.
-- Fixed a bug causing dropdown toggles in the navigation bar not firing.
 
 ### Security
 

--- a/src/components/Navigation/header/OrganizationSelector.vue
+++ b/src/components/Navigation/header/OrganizationSelector.vue
@@ -6,7 +6,7 @@
       skin="tertiary"
       variant="icon-right"
       :icon-name="isCollapsed ? 'chevron-thin-up' : 'chevron-thin-down'"
-      @onClick="isCollapsed = !isCollapsed"
+      @click.native.stop="isCollapsed = !isCollapsed"
     >
       {{ $t('general.orgs') }}
     </pkt-button>


### PR DESCRIPTION
When `PktIcons` are dynamically updated (which uses the [`v-html`](https://v2.vuejs.org/v2/api/#v-html) directive to render its contents), the clicked SVG element is somehow no longer detected by [vue-click-outside](https://github.com/vue-bulma/click-outside/tree/master) as a child element (`el.contains`) ... or something. 

This is a quick-fix, pretty hackish, and the problem is likely to reappear at some point.