### PR TITLE
Center and highlight selected periods in timeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ All notable changes to this project will be documented in this file. The format 
 - The timeline view now fills all available screen space when browsing OKRs.
 - A modal is now used to show a quick summary of objectives in the timeline
   view.
+- The timeline view now always displays all objectives. The period selector puts
+  a specified period in focus instead of filtering the objectives.
 
 ### Removed
 

--- a/src/components/GanttChart.vue
+++ b/src/components/GanttChart.vue
@@ -2,7 +2,9 @@
   <div class="gantt">
     <div class="gantt__inner">
       <div class="month-wrapper" @mousedown="startDrag">
-        <div class="today" :style="todayStyle()">{{ $t('general.today') }}</div>
+        <div ref="today" class="today" :style="todayStyle()">
+          {{ $t('general.today') }}
+        </div>
         <div class="months">
           <div
             v-for="m in months"
@@ -157,15 +159,18 @@ export default {
   watch: {
     period: {
       async handler() {
-        this.$nextTick(() =>
-          this.$refs.period.scrollIntoView({ inline: 'center', behavior: 'smooth' })
-        );
+        this.$nextTick(() => {
+          if (this.$refs.period) {
+            this.$refs.period.scrollIntoView({ inline: 'center', behavior: 'smooth' });
+          }
+        });
       },
     },
   },
 
   mounted() {
-    this.$refs.period.scrollIntoView({ inline: 'center', behavior: 'instant' });
+    const ref = this.$refs.period || this.$refs.today;
+    ref.scrollIntoView({ inline: 'center', behavior: 'instant' });
   },
 
   methods: {

--- a/src/components/GanttChart.vue
+++ b/src/components/GanttChart.vue
@@ -23,7 +23,18 @@
           ></div>
           <span class="ticks__padding"></span>
         </div>
+        <!--
+          This is only here as a reference for `scrollIntoView`. Scrolling to
+          the `.period` element risks scrolling vertically.
+        -->
+        <div
+          v-if="period.startDate"
+          ref="period"
+          class="period-ref"
+          :style="periodStyle()"
+        ></div>
       </div>
+      <div v-if="period.startDate" class="period" :style="periodStyle()"></div>
       <div v-for="group in groupedObjectives" :key="group.i" class="objective-row">
         <objective-row
           v-for="o in group.objectives"
@@ -73,7 +84,7 @@ export default {
       type: Array,
       required: true,
     },
-    item: {
+    period: {
       type: Object,
       required: true,
     },
@@ -143,6 +154,20 @@ export default {
     },
   },
 
+  watch: {
+    period: {
+      async handler() {
+        this.$nextTick(() =>
+          this.$refs.period.scrollIntoView({ inline: 'center', behavior: 'smooth' })
+        );
+      },
+    },
+  },
+
+  mounted() {
+    this.$refs.period.scrollIntoView({ inline: 'center', behavior: 'instant' });
+  },
+
   methods: {
     /*
      * Return the end date of the last goal in `row`.
@@ -207,6 +232,19 @@ export default {
         differenceInDays(this.now, startOfMonth(this.minDate)) * this.PPD +
         this.endPadding
       }px + ${this.lineWidth} / 2 - 50%))`;
+    },
+
+    periodStyle() {
+      const periodStart = this.period.startDate;
+      const periodEnd = this.period.endDate;
+
+      const margin =
+        differenceInDays(periodStart, startOfMonth(this.minDate)) * this.PPD +
+        this.endPadding;
+
+      const width = differenceInDays(periodEnd, periodStart) * this.PPD + this.PPD;
+
+      return [`margin-left: ${margin}px`, `width: ${width}px`].join(';');
     },
 
     /*
@@ -289,8 +327,9 @@ export default {
 
 <style lang="scss" scoped>
 .gantt {
-  --line-width: 0.2rem;
+  --line-width: 3px;
   --end-padding: 75px;
+  --period-offset-top: 60px;
 
   position: relative;
   display: flex;
@@ -365,16 +404,15 @@ export default {
   z-index: 2;
   display: inline-block;
   height: 1.5rem;
-  color: var(--color-yellow);
+  color: var(--color-active);
   font-weight: 500;
-  background-color: inherit;
 
   &::after {
     position: absolute;
     top: 3.125rem;
     left: calc(50% - 0.1rem);
     height: 1.125rem;
-    border-left: var(--line-width) solid var(--color-yellow);
+    border-left: var(--line-width) solid var(--color-active);
     content: '';
   }
 }
@@ -383,7 +421,25 @@ export default {
   position: absolute;
   top: 3rem;
   height: calc(100% - 3rem);
-  border-left: var(--line-width) dashed var(--color-yellow);
+  border-left: var(--line-width) dashed var(--color-active);
+}
+
+.period-ref {
+  position: absolute;
+  top: 0;
+}
+
+.period {
+  position: absolute;
+  top: var(--period-offset-top);
+  height: calc(100% - var(--period-offset-top));
+  background: repeating-linear-gradient(
+    -45deg,
+    var(--color-blue-dark-10),
+    var(--color-blue-dark-10) 4px,
+    var(--color-gray-light) 4px,
+    var(--color-gray-light) 8px
+  );
 }
 
 .objective-row {

--- a/src/components/widgets/WidgetKeyResultDetails.vue
+++ b/src/components/widgets/WidgetKeyResultDetails.vue
@@ -110,7 +110,7 @@
 import { mapState } from 'vuex';
 import { db } from '@/config/firebaseConfig';
 import { dateLong } from '@/util';
-import { formattedPeriod } from '@/util/okr';
+import formattedPeriod from '@/util/okr';
 
 export default {
   name: 'WidgetKeyResultDetails',

--- a/src/components/widgets/WidgetObjectiveDetails.vue
+++ b/src/components/widgets/WidgetObjectiveDetails.vue
@@ -70,7 +70,7 @@
 <script>
 import { mapState } from 'vuex';
 import { dateLong } from '@/util';
-import { formattedPeriod } from '@/util/okr';
+import formattedPeriod from '@/util/okr';
 
 export default {
   name: 'WidgetObjectiveDetails',

--- a/src/util/okr.js
+++ b/src/util/okr.js
@@ -1,38 +1,9 @@
 import { dateShort, periodDates } from '@/util';
 
 /**
- * Return true if `objective` is in `period`.
- *
- * "In" doesn't mean that the objective have to be fully within the period,
- * just that it overlaps the period with at least one day.
- */
-export function objectiveInPeriod(period, objective) {
-  const { startDate, endDate } = period;
-
-  if (objective.startDate && objective.endDate) {
-    return (
-      objective.endDate.toDate() >= startDate && objective.startDate.toDate() <= endDate
-    );
-  }
-
-  /*
-   * Fall back to checking the old-style `period` reference to retain backwards
-   * compatibility.
-   */
-  if (objective.period.endDate && objective.period.startDate) {
-    return (
-      objective.period.endDate.toDate() >= startDate &&
-      objective.period.startDate.toDate() <= endDate
-    );
-  }
-
-  return false;
-}
-
-/**
  * Return a nicely formatted period range for `objective`'s period.
  */
-export function formattedPeriod(objective) {
+function formattedPeriod(objective) {
   const { period, startDate, endDate } = objective;
 
   if (startDate && endDate) {
@@ -44,3 +15,5 @@ export function formattedPeriod(objective) {
 
   return null;
 }
+
+export default formattedPeriod;

--- a/src/views/Item/ItemOKRs.vue
+++ b/src/views/Item/ItemOKRs.vue
@@ -2,7 +2,7 @@
   <page-layout
     v-if="objectives.length || dataLoading"
     breakpoint="full"
-    :class="{ 'okrs--timeline': periodObjectives.length }"
+    :class="{ 'okrs--timeline': objectives.length }"
   >
     <template #header>
       <h1 class="pkt-txt-24-medium">{{ $t('general.OKRsLong') }}</h1>
@@ -23,9 +23,9 @@
       <content-loader-item v-if="dataLoading" />
 
       <gantt-chart
-        v-else-if="periodObjectives.length"
-        :objectives="periodObjectives"
-        :item="activeItem"
+        v-else-if="objectives.length"
+        :objectives="_objectives"
+        :period="selectedPeriod"
       />
 
       <empty-state
@@ -55,8 +55,6 @@
 
 <script>
 import { mapGetters, mapState, mapActions, mapMutations } from 'vuex';
-import { objectiveInPeriod } from '@/util/okr';
-import { periodDates } from '@/util';
 import routerGuard from '@/router/router-guards/itemOKRs';
 import ContentLoaderItem from '@/components/ContentLoader/ContentLoaderItem.vue';
 import { PktButton } from '@oslokommune/punkt-vue2';
@@ -93,20 +91,15 @@ export default {
       return this.user.preferences.view;
     },
 
-    periodObjectives() {
-      if (!this.selectedPeriod) {
-        return [];
-      }
-
-      return this.objectives
-        .filter((o) => objectiveInPeriod(this.selectedPeriod, o))
-        .map((o) => ({
-          ...o,
-          id: o.id,
-          keyResults: this.keyResults.filter(
-            (kr) => kr.objective === `objectives/${o.id}`
-          ),
-        }));
+    /**
+     * Return `this.objectives` enriched with ID and key results.
+     */
+    _objectives() {
+      return this.objectives.map((o) => ({
+        ...o,
+        id: o.id,
+        keyResults: this.keyResults.filter((kr) => kr.objective === `objectives/${o.id}`),
+      }));
     },
   },
 
@@ -134,8 +127,6 @@ export default {
         content: null,
       });
     },
-
-    periodDates,
   },
 };
 </script>


### PR DESCRIPTION
Always display all objectives in the timeline view. Make the period selector put a specified period in focus by centering and highlighting it instead of filtering the objectives.