### PR TITLE
Remove duplicate `objective` class

### DIFF
--- a/src/components/GanttChart.vue
+++ b/src/components/GanttChart.vue
@@ -49,7 +49,6 @@
           :style="objectiveStyle(o)"
           :is-link="false"
           :class="[
-            'objective',
             {
               'objective--selected': selectedObjectives
                 .map((o) => o.id)


### PR DESCRIPTION
The `ObjectiveRow` component already sets the `objective` class on its top level element.