### PR TITLE
Improve "not found" handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file. The format 
 - The date column now comes first in progress tables and CSV exports.
 - Export of progress graph (png) and raw data (csv) are now triggered from its
   respective widgets in the measurement details page.
+- Improved "not found" pages.
 
 ### Fixed
 

--- a/src/components/pages/NotFoundPage.vue
+++ b/src/components/pages/NotFoundPage.vue
@@ -1,0 +1,44 @@
+<template>
+  <empty-page :heading="heading" :body="body" skin="warning">
+    <router-link v-if="backTo" :to="{ name: backTo }" class="pkt-link">
+      <pkt-icon class="pkt-link__icon" name="chevron-left" />
+      {{ backText }}
+    </router-link>
+  </empty-page>
+</template>
+
+<script>
+import EmptyPage from '@/components/pages/EmptyPage.vue';
+import i18n from '@/locale/i18n';
+
+export default {
+  name: 'NotFoundPage',
+
+  components: {
+    EmptyPage,
+  },
+
+  props: {
+    heading: {
+      type: String,
+      required: false,
+      default: i18n.t('notFound.title'),
+    },
+    body: {
+      type: String,
+      required: false,
+      default: i18n.t('notFound.body'),
+    },
+    backTo: {
+      type: String,
+      required: false,
+      default: null,
+    },
+    backText: {
+      type: String,
+      required: false,
+      default: i18n.t('notFound.linkText'),
+    },
+  },
+};
+</script>

--- a/src/locale/locales/en-US.json
+++ b/src/locale/locales/en-US.json
@@ -4,10 +4,17 @@
     "body": "You do not have access to this page.",
     "linkText": "Go back to the front page"
   },
-  "404": {
+  "notFound": {
     "title": "Page not found",
-    "body": "This page does not seem to exist.",
-    "linkText": "Go back to the front page"
+    "body": "This page doesn't seem to exist.",
+    "linkText": "Go back to the front page",
+    "linkTextAlt": "Go back to {page}",
+    "objectiveHeading": "Objective not found",
+    "objectiveBody": "This objective doesn't seem to exist.",
+    "keyResultHeading": "Key result not found",
+    "keyResultBody": "This key result doesn't seem to exist.",
+    "measurementHeading": "Measurement not found",
+    "measurementBody": "This measurement doesn't seem to exist."
   },
   "kpi": {
     "add": "Add measurement",

--- a/src/locale/locales/nb-NO.json
+++ b/src/locale/locales/nb-NO.json
@@ -4,10 +4,17 @@
     "body": "Du har ikke tilgang til denne siden.",
     "linkText": "Gå tilbake til forsiden"
   },
-  "404": {
+  "notFound": {
     "title": "Siden finnes ikke",
     "body": "Denne siden ser ikke ut til å eksistere.",
-    "linkText": "Gå tilbake til forsiden"
+    "linkText": "Gå tilbake til forsiden",
+    "linkTextAlt": "Gå tilbake til {page}",
+    "objectiveHeading": "Målet finnes ikke",
+    "objectiveBody": "Dette målet ser ikke ut til å eksistere.",
+    "keyResultHeading": "Nøkkelresultatet finnes ikke",
+    "keyResultBody": "Dette nøkkelresultatet ser ikke ut til å eksistere.",
+    "measurementHeading": "Målingen finnes ikke",
+    "measurementBody": "Denne målingen ser ikke ut til å eksistere."
   },
   "kpi": {
     "add": "Legg til måling",

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -35,11 +35,6 @@ const routes = [
     component: () => import('@/views/Forbidden.vue'),
   },
   {
-    path: '/404',
-    name: 'Not found',
-    component: () => import('@/views/NotFound.vue'),
-  },
-  {
     path: '/admin',
     beforeEnter: routerGuards.admin,
     component: () => import('@/views/Admin/AdminWrapper.vue'),
@@ -131,6 +126,11 @@ const routes = [
         redirect: { name: 'ItemMeasurements' },
       },
     ],
+  },
+  {
+    path: '*',
+    name: 'NotFound',
+    component: () => import('@/views/NotFound.vue'),
   },
 ];
 

--- a/src/router/router-guards/itemCommon.js
+++ b/src/router/router-guards/itemCommon.js
@@ -8,25 +8,20 @@ const { state } = store;
  * and their sub-pages.
  */
 export default async function itemCommon(to, from, next) {
+  if (!state.user) {
+    return next({
+      name: 'Login',
+      query: { redirectFrom: to.fullPath },
+    });
+  }
+
   const { activeItem } = state;
   const { slug } = to.params;
+  const slugRef = await getSlugRef(slug);
 
-  try {
-    const slugRef = await getSlugRef(slug);
-
-    if (!activeItem || !slugRef || activeItem.id !== slugRef.id) {
-      await store.dispatch('set_active_item', slugRef);
-    }
-
-    next();
-  } catch ({ message }) {
-    if (!state.user) {
-      next({
-        name: 'Login',
-        query: { redirectFrom: to.fullPath },
-      });
-    } else {
-      next({ name: 'Not found' });
-    }
+  if (!activeItem || !slugRef || activeItem.id !== slugRef.id) {
+    await store.dispatch('set_active_item', slugRef);
   }
+
+  return next();
 }

--- a/src/router/router-guards/itemMeasurements.js
+++ b/src/router/router-guards/itemMeasurements.js
@@ -7,6 +7,10 @@ const { state } = store;
 export default async function itemMeasurements(to, from, next) {
   const { activeItem } = state;
 
+  if (!activeItem) {
+    return next();
+  }
+
   try {
     const periods = getPeriods();
 
@@ -26,9 +30,9 @@ export default async function itemMeasurements(to, from, next) {
       });
     }
     await store.dispatch('set_sub_kpis', activeItem.id);
-    next();
+    return next();
   } catch (error) {
     console.error(error);
-    next(false);
+    return next(false);
   }
 }

--- a/src/router/router-guards/objectiveHome.js
+++ b/src/router/router-guards/objectiveHome.js
@@ -4,12 +4,12 @@ export default async function objectiveHome(to, from, next) {
   const { objectiveId } = to.params;
 
   try {
-    const { period } = await store.dispatch('set_active_objective', objectiveId);
+    const activeObjective = await store.dispatch('set_active_objective', objectiveId);
     const { activeItem, activePeriod } = store.state;
 
-    if (!activePeriod || activePeriod.id !== period?.id) {
+    if (!activePeriod || activePeriod.id !== activeObjective?.period?.id) {
       await store.dispatch('set_active_period_and_data', {
-        periodId: period?.id,
+        periodId: activeObjective?.period?.id,
         item: activeItem,
       });
     }

--- a/src/router/router-guards/routerGuardUtil.js
+++ b/src/router/router-guards/routerGuardUtil.js
@@ -6,17 +6,19 @@ const getSlugRef = async (slug) => {
   const slugSnapshot = await db.doc(`slugs/${firestoreEncode(slug)}`).get();
 
   if (!slugSnapshot.exists) {
-    throw new Error(`cannot find ${slug}`);
+    return null;
   }
   const { reference } = slugSnapshot.data();
 
-  const { archived } = await reference.get().then((snap) => snap.data());
+  const refData = await reference
+    .get()
+    .then((snap) => snap.data())
+    .catch(() => null);
 
-  if (archived && (!store.state.user.admin || !store.state.user.superAdmin)) {
-    throw new Error(`cannot find ${slug}`);
-  }
-
-  return reference;
+  return !refData ||
+    (refData.archived && (!store.state.user.admin || !store.state.user.superAdmin))
+    ? null
+    : reference;
 };
 
 export default getSlugRef;

--- a/src/store/actions/set_active_key_result.js
+++ b/src/store/actions/set_active_key_result.js
@@ -7,8 +7,13 @@ export default firestoreAction(
       return unbindFirestoreRef('activeKeyResult');
     }
     const reference = db.collection('keyResults').doc(id);
+    const refData = await reference.get().then((snapshot) => snapshot.data());
 
-    const { objective } = await reference.get().then((snapshot) => snapshot.data());
+    if (!refData) {
+      return unbindFirestoreRef('activeKeyResult');
+    }
+
+    const objective = refData.objective;
 
     if (!state.activeObjective || state.activeObjective.id !== objective.id) {
       await bindFirestoreRef('activeObjective', objective, { maxRefDepth: 1 });

--- a/src/views/Item/ItemMeasurements.vue
+++ b/src/views/Item/ItemMeasurements.vue
@@ -17,8 +17,13 @@
       </template>
     </template>
 
-    <template #default>
-      <kpi-details v-if="showKpiDetails && kpi" :kpi="kpi" />
+    <template v-if="showKpiDetails" #default>
+      <kpi-details v-if="kpi" :kpi="kpi" />
+      <not-found-page
+        v-else
+        :heading="$t('notFound.measurementHeading')"
+        :body="$t('notFound.measurementBody')"
+      />
     </template>
   </page-layout>
 
@@ -44,6 +49,7 @@ import { mapState, mapGetters } from 'vuex';
 
 import KpiWidgetGroup from '@/components/KpiWidgetGroup.vue';
 import KpiDetails from '@/components/KpiDetails.vue';
+import NotFoundPage from '@/components/pages/NotFoundPage.vue';
 
 export default {
   name: 'ItemMeasurements',
@@ -53,6 +59,7 @@ export default {
     KpiDetails,
     EmptyPage: () => import('@/components/pages/EmptyPage.vue'),
     PktButton: () => import('@oslokommune/punkt-vue2').then(({ PktButton }) => PktButton),
+    NotFoundPage,
   },
 
   data: () => ({

--- a/src/views/Item/ItemMeasurements.vue
+++ b/src/views/Item/ItemMeasurements.vue
@@ -49,7 +49,6 @@ import { mapState, mapGetters } from 'vuex';
 
 import KpiWidgetGroup from '@/components/KpiWidgetGroup.vue';
 import KpiDetails from '@/components/KpiDetails.vue';
-import NotFoundPage from '@/components/pages/NotFoundPage.vue';
 
 export default {
   name: 'ItemMeasurements',
@@ -59,7 +58,7 @@ export default {
     KpiDetails,
     EmptyPage: () => import('@/components/pages/EmptyPage.vue'),
     PktButton: () => import('@oslokommune/punkt-vue2').then(({ PktButton }) => PktButton),
-    NotFoundPage,
+    NotFoundPage: () => import('@/components/pages/NotFoundPage.vue'),
   },
 
   data: () => ({

--- a/src/views/Item/ItemWrapper.vue
+++ b/src/views/Item/ItemWrapper.vue
@@ -1,28 +1,18 @@
 <template>
   <router-view v-if="activeItem" v-show="!loading"></router-view>
-  <empty-page
-    v-else
-    :heading="$t('notFound.title')"
-    :body="$t('notFound.body')"
-    skin="warning"
-  >
-    <router-link :to="{ name: 'Home' }" class="pkt-link">
-      <pkt-icon class="pkt-link__icon" name="chevron-left" />
-      {{ $t('notFound.linkText') }}
-    </router-link>
-  </empty-page>
+  <not-found-page v-else back-to="Home" />
 </template>
 
 <script>
 import { mapState } from 'vuex';
-import EmptyPage from '@/components/pages/EmptyPage.vue';
+import NotFoundPage from '@/components/pages/NotFoundPage.vue';
 import { itemCommon as routerGuard } from '@/router/router-guards';
 
 export default {
   name: 'ItemWrapper',
 
   components: {
-    EmptyPage,
+    NotFoundPage,
   },
 
   async beforeRouteUpdate(to, from, next) {

--- a/src/views/Item/ItemWrapper.vue
+++ b/src/views/Item/ItemWrapper.vue
@@ -1,12 +1,29 @@
 <template>
-  <router-view v-show="!loading"></router-view>
+  <router-view v-if="activeItem" v-show="!loading"></router-view>
+  <empty-page
+    v-else
+    :heading="$t('notFound.title')"
+    :body="$t('notFound.body')"
+    skin="warning"
+  >
+    <router-link :to="{ name: 'Home' }" class="pkt-link">
+      <pkt-icon class="pkt-link__icon" name="chevron-left" />
+      {{ $t('notFound.linkText') }}
+    </router-link>
+  </empty-page>
 </template>
 
 <script>
+import { mapState } from 'vuex';
+import EmptyPage from '@/components/pages/EmptyPage.vue';
 import { itemCommon as routerGuard } from '@/router/router-guards';
 
 export default {
   name: 'ItemWrapper',
+
+  components: {
+    EmptyPage,
+  },
 
   async beforeRouteUpdate(to, from, next) {
     this.loading = true;
@@ -22,6 +39,10 @@ export default {
   data: () => ({
     loading: true,
   }),
+
+  computed: {
+    ...mapState(['activeItem']),
+  },
 
   mounted() {
     this.loading = false;

--- a/src/views/Item/ItemWrapper.vue
+++ b/src/views/Item/ItemWrapper.vue
@@ -5,14 +5,13 @@
 
 <script>
 import { mapState } from 'vuex';
-import NotFoundPage from '@/components/pages/NotFoundPage.vue';
 import { itemCommon as routerGuard } from '@/router/router-guards';
 
 export default {
   name: 'ItemWrapper',
 
   components: {
-    NotFoundPage,
+    NotFoundPage: () => import('@/components/pages/NotFoundPage.vue'),
   },
 
   async beforeRouteUpdate(to, from, next) {

--- a/src/views/KeyResultHome.vue
+++ b/src/views/KeyResultHome.vue
@@ -114,7 +114,6 @@
 import { mapGetters, mapState } from 'vuex';
 import { format } from 'd3-format';
 import { max, min } from 'd3-array';
-import NotFoundPage from '@/components/pages/NotFoundPage.vue';
 import { db } from '@/config/firebaseConfig';
 import KeyResult from '@/db/KeyResult';
 import Progress from '@/db/Progress';
@@ -133,7 +132,7 @@ export default {
   name: 'KeyResultHome',
 
   components: {
-    NotFoundPage,
+    NotFoundPage: () => import('@/components/pages/NotFoundPage.vue'),
     ProgressBar: () => import('@/components/ProgressBar.vue'),
     PktAlert: () => import('@oslokommune/punkt-vue2').then(({ PktAlert }) => PktAlert),
     KeyResultProgressDetails,

--- a/src/views/KeyResultHome.vue
+++ b/src/views/KeyResultHome.vue
@@ -101,12 +101,20 @@
       <widget-key-result-details />
     </template>
   </page-layout>
+  <not-found-page
+    v-else
+    :heading="$t('notFound.keyResultHeading')"
+    :body="$t('notFound.keyResultBody')"
+    back-to="ItemHome"
+    :back-text="$t('notFound.linkTextAlt', { page: activeItem.name })"
+  />
 </template>
 
 <script>
 import { mapGetters, mapState } from 'vuex';
 import { format } from 'd3-format';
 import { max, min } from 'd3-array';
+import NotFoundPage from '@/components/pages/NotFoundPage.vue';
 import { db } from '@/config/firebaseConfig';
 import KeyResult from '@/db/KeyResult';
 import Progress from '@/db/Progress';
@@ -125,6 +133,7 @@ export default {
   name: 'KeyResultHome',
 
   components: {
+    NotFoundPage,
     ProgressBar: () => import('@/components/ProgressBar.vue'),
     PktAlert: () => import('@oslokommune/punkt-vue2').then(({ PktAlert }) => PktAlert),
     KeyResultProgressDetails,

--- a/src/views/NotFound.vue
+++ b/src/views/NotFound.vue
@@ -4,12 +4,11 @@
 
 <script>
 import i18n from '@/locale/i18n';
-import NotFoundPage from '@/components/pages/NotFoundPage.vue';
 
 export default {
   name: 'NotFound',
   components: {
-    NotFoundPage,
+    NotFoundPage: () => import('@/components/pages/NotFoundPage.vue'),
   },
 
   metaInfo() {

--- a/src/views/NotFound.vue
+++ b/src/views/NotFound.vue
@@ -1,8 +1,8 @@
 <template>
-  <empty-page :heading="$t('404.title')" :body="$t('404.body')" skin="warning">
+  <empty-page :heading="$t('notFound.title')" :body="$t('notFound.body')" skin="warning">
     <router-link :to="{ name: 'Home' }" class="pkt-link">
       <pkt-icon class="pkt-link__icon" name="chevron-left" />
-      {{ $t('404.linkText') }}
+      {{ $t('notFound.linkText') }}
     </router-link>
   </empty-page>
 </template>
@@ -19,7 +19,7 @@ export default {
 
   metaInfo() {
     return {
-      title: `${i18n.t('404.title')} | ${i18n.t('general.project')}`,
+      title: `${i18n.t('notFound.title')} | ${i18n.t('general.project')}`,
     };
   },
 };

--- a/src/views/NotFound.vue
+++ b/src/views/NotFound.vue
@@ -1,20 +1,15 @@
 <template>
-  <empty-page :heading="$t('notFound.title')" :body="$t('notFound.body')" skin="warning">
-    <router-link :to="{ name: 'Home' }" class="pkt-link">
-      <pkt-icon class="pkt-link__icon" name="chevron-left" />
-      {{ $t('notFound.linkText') }}
-    </router-link>
-  </empty-page>
+  <not-found-page back-to="Home" />
 </template>
 
 <script>
 import i18n from '@/locale/i18n';
-import EmptyPage from '@/components/pages/EmptyPage.vue';
+import NotFoundPage from '@/components/pages/NotFoundPage.vue';
 
 export default {
   name: 'NotFound',
   components: {
-    EmptyPage,
+    NotFoundPage,
   },
 
   metaInfo() {

--- a/src/views/ObjectiveHome.vue
+++ b/src/views/ObjectiveHome.vue
@@ -87,10 +87,18 @@
       <widget-objective-details />
     </template>
   </page-layout>
+  <not-found-page
+    v-else
+    :heading="$t('notFound.objectiveHeading')"
+    :body="$t('notFound.objectiveBody')"
+    back-to="ItemHome"
+    :back-text="$t('notFound.linkTextAlt', { page: activeItem.name })"
+  />
 </template>
 
 <script>
 import { mapGetters, mapState } from 'vuex';
+import NotFoundPage from '@/components/pages/NotFoundPage.vue';
 import Objective from '@/db/Objective';
 import routerGuard from '@/router/router-guards/objectiveHome';
 import WidgetWrapper from '@/components/widgets/WidgetWrapper.vue';
@@ -104,6 +112,7 @@ export default {
 
   components: {
     KeyResultsList: () => import('@/components/KeyResultsList.vue'),
+    NotFoundPage,
     Widget: WidgetWrapper,
     WidgetWeights,
     WidgetObjectiveDetails,
@@ -133,7 +142,7 @@ export default {
   }),
 
   computed: {
-    ...mapState(['activeObjective', 'keyResults']),
+    ...mapState(['activeObjective', 'activeItem', 'keyResults']),
     ...mapGetters(['hasEditRights']),
 
     period() {

--- a/src/views/ObjectiveHome.vue
+++ b/src/views/ObjectiveHome.vue
@@ -98,7 +98,6 @@
 
 <script>
 import { mapGetters, mapState } from 'vuex';
-import NotFoundPage from '@/components/pages/NotFoundPage.vue';
 import Objective from '@/db/Objective';
 import routerGuard from '@/router/router-guards/objectiveHome';
 import WidgetWrapper from '@/components/widgets/WidgetWrapper.vue';
@@ -112,7 +111,7 @@ export default {
 
   components: {
     KeyResultsList: () => import('@/components/KeyResultsList.vue'),
-    NotFoundPage,
+    NotFoundPage: () => import('@/components/pages/NotFoundPage.vue'),
     Widget: WidgetWrapper,
     WidgetWeights,
     WidgetObjectiveDetails,


### PR DESCRIPTION
Improve "not found" handling by not redirecting to a dedicated `/404` route anymore. Handle not found documents locally instead, which gives the opportunity for more intelligent/local error pages.

Also add a catchall "not found" page for paths that don't match any route.