### PR TITLE
Reorder date and value in progress tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file. The format 
 
 - Measurements can now be rearranged by drag and drop on the measurement list
   and detail pages.
+- The date column now comes first in progress tables and CSV exports.
 
 ### Fixed
 

--- a/src/components/widgets/WidgetKpiProgressGraph.vue
+++ b/src/components/widgets/WidgetKpiProgressGraph.vue
@@ -165,14 +165,14 @@ export default {
       } else if (value.downloadOption === 'csv') {
         const content = [
           csvFormatRow([
-            i18n.t('fields.value'),
             i18n.t('fields.date'),
+            i18n.t('fields.value'),
             i18n.t('fields.comment'),
           ]),
           csvFormatBody(
             this.progress.map((d) => [
-              d.value,
               d.timestamp.toDate().toISOString().slice(0, 10),
+              d.value,
               d.comment,
             ])
           ),

--- a/src/components/widgets/WidgetProgressHistory/ProgressHistoryTable.vue
+++ b/src/components/widgets/WidgetProgressHistory/ProgressHistoryTable.vue
@@ -3,8 +3,8 @@
     <table v-if="historyRecords.length" class="table">
       <thead>
         <tr>
-          <th>{{ $t('widget.history.value') }}</th>
           <th>{{ $t('widget.history.date') }}</th>
+          <th>{{ $t('widget.history.value') }}</th>
           <th v-if="hasAnyChangedBy">
             {{ $t('widget.history.changedBy') }}
           </th>
@@ -31,10 +31,10 @@
       <tbody>
         <tr v-for="record in historyRecords" :key="record.id">
           <td>
-            <slot name="value-cell" :record="record">{{ record.value }}</slot>
+            <slot name="date-cell" :record="record">{{ record.timestamp.toDate() }}</slot>
           </td>
           <td>
-            <slot name="date-cell" :record="record">{{ record.timestamp.toDate() }}</slot>
+            <slot name="value-cell" :record="record">{{ record.value }}</slot>
           </td>
           <td v-if="hasAnyChangedBy">
             <user-link


### PR DESCRIPTION
Reorder the date and value columns in progress tables (both on the web pages and in the CSV exports) so that the date comes first.