### PR TITLE
Upgrade to Node.js 18 (LTS)

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -19,10 +19,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
 
-      - name: Use Node.js 16
+      - name: Use Node.js 18
         uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
         with:
-          node-version: 16
+          node-version: 18
 
       - name: Populate env file
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [18.x]
 
     steps:
       - name: Checkout repository

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ All notable changes to this project will be documented in this file. The format 
 - Improved "not found" pages.
 - All icons are now provided by Punkt and the previous icon provider, Font
   Awesome, is no longer loaded.
+- Node.js 18 is now the default runtime for all Cloud Functions and when running
+  the app locally.
+
+### Removed
+
+- Dropped support for Node.js 16 and below.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ If you would like to check out how the application works, you can go to the demo
 
 ## Project requirements
 
-- Node 16.x
+- Node 18.x
 - Firebase >=8.x (v9 is not supported)
 - Firebase tools >9.x
 - Firebase Blaze plan - Pay as you go

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -25,7 +25,7 @@
         "firebase-functions-test": "^0.3.3"
       },
       "engines": {
-        "node": "16"
+        "node": "18"
       }
     },
     "node_modules/@babel/parser": {

--- a/functions/package.json
+++ b/functions/package.json
@@ -11,7 +11,7 @@
     "logs": "firebase functions:log"
   },
   "engines": {
-    "node": "16"
+    "node": "18"
   },
   "dependencies": {
     "@slack/web-api": "6.5.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -81,7 +81,7 @@
         "vite": "^4.1.5"
       },
       "engines": {
-        "node": "16"
+        "node": "18"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "export_mock_data": "firebase emulators:export ./mock_data"
   },
   "engines": {
-    "node": "16"
+    "node": "18"
   },
   "dependencies": {
     "@oslokommune/punkt-vue2": "^5.0.8",


### PR DESCRIPTION
Drop support for Node.js 16 which is reaching its end of life soon and upgrade to the Node.js 18 (LTS) runtime for Cloud Functions, local scripts, and GitHub Actions.