### PR TITLE
Add period shortcut when creating a new objective

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [UNRELEASED]
 
+### Added
+
+- Added a shortcut to quickly select the last used period when creating a new
+  objective.
+
 ### Changed
 
 - Measurements can now be rearranged by drag and drop on the measurement list

--- a/src/components/drawers/EditObjective.vue
+++ b/src/components/drawers/EditObjective.vue
@@ -42,6 +42,16 @@
           rules="required"
         />
 
+        <pkt-button
+          v-if="newestObjective?.startDate && newestObjective?.endDate"
+          class="period-suggestion"
+          skin="secondary"
+          size="small"
+          @onClick="useSuggestedPeriod"
+        >
+          {{ formattedPeriod(newestObjective) }}
+        </pkt-button>
+
         <template v-if="!objective?.archived" #actions="{ handleSubmit }">
           <btn-cancel :disabled="loading" @click="close" />
           <btn-save
@@ -99,6 +109,7 @@
 
 <script>
 import { mapState } from 'vuex';
+import formattedPeriod from '@/util/okr';
 import Objective from '@/db/Objective';
 import firebase from 'firebase/compat/app';
 import locale from 'flatpickr/dist/l10n/no';
@@ -127,6 +138,12 @@ export default {
     },
 
     objective: {
+      type: Object,
+      required: false,
+      default: null,
+    },
+
+    newestObjective: {
       type: Object,
       required: false,
       default: null,
@@ -173,6 +190,8 @@ export default {
   },
 
   methods: {
+    formattedPeriod,
+
     getCurrentDateRange() {
       if (this.thisObjective.startDate && this.thisObjective.endDate) {
         return [this.objective.startDate.toDate(), this.objective.endDate.toDate()];
@@ -254,6 +273,19 @@ export default {
     close(e) {
       this.$emit('close', e);
     },
+
+    async useSuggestedPeriod() {
+      this.periodRange = [
+        this.newestObjective.startDate.toDate(),
+        this.newestObjective.endDate.toDate(),
+      ];
+    },
   },
 };
 </script>
+
+<style lang="scss" scoped>
+.period-suggestion {
+  margin-bottom: 1rem;
+}
+</style>

--- a/src/views/Item/ItemOKRs.vue
+++ b/src/views/Item/ItemOKRs.vue
@@ -41,6 +41,7 @@
 
       <objective-drawer
         :visible="showObjectiveDrawer"
+        :newest-objective="newestObjective"
         @close="showObjectiveDrawer = false"
       />
     </template>
@@ -103,6 +104,22 @@ export default {
 
     view() {
       return this.user.preferences.view;
+    },
+
+    /**
+     * Return the most recently created objective for the current item.
+     */
+    newestObjective() {
+      if (!this.objectivesWithKeyResults.length) {
+        return null;
+      }
+
+      return this.objectivesWithKeyResults.slice().sort((a, b) => {
+        if (a.created && b.created) {
+          return a.created.seconds > b.created.seconds ? -1 : 1;
+        }
+        return 0;
+      })[0];
     },
   },
 


### PR DESCRIPTION
Add a shortcut to quickly select the last used period when creating a new objective.