### PR TITLE
Fix centering of period in the timeline view

### DIFF
--- a/src/components/GanttChart.vue
+++ b/src/components/GanttChart.vue
@@ -246,11 +246,17 @@ export default {
         });
       },
     },
-  },
 
-  mounted() {
-    const ref = this.$refs.period || this.$refs.today;
-    ref.scrollIntoView({ inline: 'center', behavior: 'instant' });
+    loading: {
+      async handler() {
+        if (!this.loading) {
+          this.$nextTick(() => {
+            const ref = this.$refs.period || this.$refs.today;
+            ref.scrollIntoView({ inline: 'center', behavior: 'instant' });
+          });
+        }
+      },
+    },
   },
 
   methods: {


### PR DESCRIPTION
Fix centering of period in the timeline view after the new loading state was implemented.