### PR TITLE
Load external objectives in the timeline view

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -149,6 +149,13 @@ service cloud.firestore {
       allow delete: if isSuperAdmin();
     }
 
+    /*
+     * TODO: Needs to be extended with rules for `create` and `delete`.
+     */
+    match /objectiveContributors/{document} {
+      allow read: if isSignedIn();
+    }
+
     match /periods/{document} {
       allow read: if isSignedIn();
     }

--- a/src/store/actions/set_active_period_and_data.js
+++ b/src/store/actions/set_active_period_and_data.js
@@ -7,6 +7,7 @@ export default firestoreAction(
     if (!periodId && !item) {
       unbindFirestoreRef('periods');
       unbindFirestoreRef('objectives');
+      unbindFirestoreRef('objectiveContributors');
       unbindFirestoreRef('activePeriod');
       return false;
     }
@@ -28,14 +29,26 @@ export default firestoreAction(
       .where('parent', '==', parentRef)
       .orderBy('name');
 
+    const objectiveContributorsRef = db
+      .collection('objectiveContributors')
+      .where('item', '==', parentRef);
+
     const activeObjectivesList = await objectivesRef
       .get()
       .then((snapshot) => snapshot.docs.map((doc) => doc.ref));
 
-    if (activeObjectivesList.length) {
+    const objectiveContributorsList = await objectiveContributorsRef
+      .get()
+      .then((snapshot) => snapshot.docs.map((doc) => doc.ref));
+
+    if (activeObjectivesList.length || objectiveContributorsList.length) {
       await bindFirestoreRef('objectives', objectivesRef, { maxRefDepth: 1 });
+      await bindFirestoreRef('objectiveContributors', objectiveContributorsRef, {
+        maxRefDepth: 1,
+      });
     } else {
       unbindFirestoreRef('objectives');
+      unbindFirestoreRef('objectiveContributors');
     }
 
     return true;

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -126,10 +126,13 @@ export const storeGetters = {
   },
 
   /**
-   * Return `state.objectives` enriched with ID.
+   * Return `state.objectives` and external objectives from
+   * `state.objectiveContributors` enriched with ID.
    */
   objectivesWithID: (state) => {
-    return state.objectives.map((o) => ({
+    const externalObjectives = state.objectiveContributors.map((oc) => oc.objective);
+
+    return state.objectives.concat(externalObjectives).map((o) => ({
       ...o,
       id: o.id,
     }));
@@ -276,6 +279,7 @@ export default new Vuex.Store({
     activeObjective: null,
     periods: [],
     objectives: [],
+    objectiveContributors: [],
     kpis: [],
     subKpis: [],
     loginError: null,

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -130,7 +130,9 @@ export const storeGetters = {
    * `state.objectiveContributors` enriched with ID.
    */
   objectivesWithID: (state) => {
-    const externalObjectives = state.objectiveContributors.map((oc) => oc.objective);
+    const externalObjectives = state.objectiveContributors
+      .filter((oc) => typeof oc.objective !== 'string')
+      .map((oc) => oc.objective);
 
     return state.objectives.concat(externalObjectives).map((o) => ({
       ...o,


### PR DESCRIPTION
Load external objectives (objectives that the current item are "contributors" to (as per a new `objectiveContributors` table)) in the timeline view.

There is currently no way to create `objectiveContributors` entries in the web UI, but this lays the groundwork for it.

Depends on ~~https://github.com/oslokommune/okr-tracker/pull/836~~.