### PR TITLE
Simplify graph legend for measurements

### DIFF
--- a/src/util/LineChart/index.js
+++ b/src/util/LineChart/index.js
@@ -235,7 +235,7 @@ export default class LineChart {
     if (this.legend) {
       const legendItems = [
         {
-          label: kpi ? kpi.name : i18n.t('general.value'),
+          label: kpi ? i18n.t('kpi.progress') : i18n.t('general.value'),
           color: GRAPH_COLORS.valueLine,
         },
         ...(targets && targets.length


### PR DESCRIPTION
Possibly a bit clearer to the user (?) with the added bonus of circumventing issues caused by non-limited KPI-titles.

<img width="338" alt="image" src="https://github.com/oslokommune/okr-tracker/assets/2866225/a0cc2776-d8d4-41ac-a641-e8276851b687">
