### PR TITLE
Don't render HTML in tooltips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,10 @@ All notable changes to this project will be documented in this file. The format 
 - The admin panel tab has been completely removed from the item tab bar (all
   functionality moved to drawers).
 
+### Security
+
+- Fixed an XSS issue with the rendering of tooltips.
+
 ## [3.9.0] 2023-09-01
 
 ### Added

--- a/src/main.js
+++ b/src/main.js
@@ -31,7 +31,9 @@ Vue.use(Toasted, {
   className: 'toast',
   duration: 3500,
 });
-Vue.use(VTooltip);
+Vue.use(VTooltip, {
+  defaultHtml: false,
+});
 Vue.use(VueMeta);
 Vue.use(firestorePlugin);
 Vue.use(VueFlatPickr);


### PR DESCRIPTION
This fixes an XSS issue because the v-tooltip library is rendering HTML by default.