### PR TITLE
Make tweaks to the drag and drop styling

### DIFF
--- a/src/components/KpiWidgetGroup.vue
+++ b/src/components/KpiWidgetGroup.vue
@@ -24,7 +24,7 @@
         </pkt-button>
       </template>
     </div>
-    <draggable v-if="hasEditRights" v-model="orderedKpis" animation="200">
+    <draggable v-if="hasEditRights" v-model="orderedKpis" animation="300">
       <transition-group class="kpi-widget-group__kpis">
         <kpi-widget-group-link
           v-for="kpi in orderedKpis"
@@ -173,6 +173,21 @@ export default {
 
     .kpi-widget-group__title h2 {
       @include get-text('pkt-txt-14');
+    }
+  }
+}
+
+::v-deep .kpi-widget-group-link.sortable-ghost * {
+  color: var(--color-grayscale-10) !important;
+  background: var(--color-grayscale-10) !important;
+  border-color: var(--color-grayscale-10) !important;
+  fill: var(--color-grayscale-10);
+  stroke: var(--color-grayscale-10);
+
+  & .period-trend-tag__trend {
+    &::after,
+    &::before {
+      border-color: var(--color-grayscale-10);
     }
   }
 }

--- a/src/components/panes/ObjectivePane.vue
+++ b/src/components/panes/ObjectivePane.vue
@@ -96,7 +96,7 @@
         v-else-if="hasEditRights && keyResults.length"
         v-model="orderedKeyResults"
         class="objective-pane__key-results-list"
-        animation="200"
+        animation="300"
       >
         <transition-group>
           <key-result-link-card
@@ -377,6 +377,17 @@ export default {
             height: calc(50% + 1.5rem);
             content: '';
           }
+        }
+      }
+
+      ::v-deep & .sortable-ghost {
+        background: var(--color-grayscale-10);
+        border-color: var(--color-grayscale-10);
+
+        & .key-result-link-card__inner * {
+          color: var(--color-grayscale-10);
+          background: var(--color-grayscale-10) !important;
+          border-color: var(--color-grayscale-10);
         }
       }
     }


### PR DESCRIPTION
Make tweaks to the drag and drop styling:

- Slow down the animation a tad.

- Make the placeholder ("ghost") totally gray.

- Hide the border things in the key results list for the ghost element.