### PR TITLE
Improve key result defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [UNRELEASED]
 
+### Changed
+
+- New key results are now given a start value of 0, a target value of 100, and
+  percentage as unit of measurement by default.
+
 ## [3.10.0] 2023-10-10
 
 ### Changed

--- a/src/components/drawers/EditKeyResult.vue
+++ b/src/components/drawers/EditKeyResult.vue
@@ -204,6 +204,8 @@ export default {
     thisKeyResult: null,
     keyResultDefaults: {
       weight: 1,
+      startValue: 0,
+      targetValue: 100,
     },
     pageCount: 2,
     loading: false,
@@ -263,6 +265,8 @@ export default {
           this.thisKeyResult = null;
           return;
         }
+
+        this.keyResultDefaults.unit = this.$t('keyResult.defaultUnit');
 
         this.thisKeyResult = this.keyResult
           ? { ...this.keyResultDefaults, ...this.keyResult }

--- a/src/locale/locales/en-US.json
+++ b/src/locale/locales/en-US.json
@@ -348,6 +348,7 @@
     "startValue": "Start value",
     "targetValue": "Target value",
     "unit": "Unit of measurement",
+    "defaultUnit": "percent",
     "newValue": "New value",
     "editValue": "Edit value",
     "automation": {

--- a/src/locale/locales/nb-NO.json
+++ b/src/locale/locales/nb-NO.json
@@ -348,6 +348,7 @@
     "startValue": "Startverdi",
     "targetValue": "Målverdi",
     "unit": "Måleenhet",
+    "defaultUnit": "prosent",
     "newValue": "Ny verdi",
     "editValue": "Endre verdi",
     "automation": {


### PR DESCRIPTION
Give new key results a start value of 0, a target value of 100, and percentage as unit of measurement by default.