### PR TITLE
Disregard whitespace in whitelist check

### DIFF
--- a/functions/backend/utils/collectionUtils/DomainWhitelistCollection.js
+++ b/functions/backend/utils/collectionUtils/DomainWhitelistCollection.js
@@ -3,8 +3,8 @@ class DomainWhitelistCollection {
     this.collection = firestore.collection('domainWhitelist');
   }
 
-  getDocumentById(id) {
-    return this.collection.doc(id).get();
+  listDocuments() {
+    return this.collection.listDocuments();
   }
 }
 

--- a/functions/backend/utils/handleAccessRequests.js
+++ b/functions/backend/utils/handleAccessRequests.js
@@ -27,15 +27,13 @@ export const createAccessRequest = async (db, accessRequest) => {
     return { code: 400, message: 'toaster.request.noEmail' };
   }
 
-  const emailDomain = email.split('@')[1];
+  const emailDomain = email.split('@')[1].trim();
   const domainWhitelistCollection = new DomainWhitelistCollection(db);
   const usersCollection = new UsersCollection(db);
 
-  const domainWhitelistSnapshot = await domainWhitelistCollection.getDocumentById(
-    emailDomain
-  );
+  const whitelist = await domainWhitelistCollection.listDocuments();
 
-  if (domainWhitelistSnapshot.exists) {
+  if (whitelist.some((x) => x.id.trim() === emailDomain)) {
     try {
       await usersCollection.addDocument({ id: email, email });
 


### PR DESCRIPTION
Disregard leading and trailing whitespace in both input email and whitelisted domains to make the check more robust against unintentionally added whitespace.