### PR TITLE
Fix Markdown rendering in descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ All notable changes to this project will be documented in this file. The format 
 - New key results are now given a start value of 0, a target value of 100, and
   percentage as unit of measurement by default.
 
+### Fixed
+
+- Fixed Markdown rendering of descriptions on objective, key result, and
+  measurement detail pages.
+
 ### Security
 
 - More security headers are now set: `Content-Security-Policy`,

--- a/src/components/HTMLOutput.vue
+++ b/src/components/HTMLOutput.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-html="sanitizedHtml" />
+  <div class="md" v-html="sanitizedHtml" />
 </template>
 
 <script>


### PR DESCRIPTION
Fix Markdown rendering of descriptions on objective, key result, and measurement detail pages.