### PR TITLE
Fix CodeQL warning about useless conditional

### DIFF
--- a/src/store/index.js
+++ b/src/store/index.js
@@ -86,7 +86,7 @@ export const storeGetters = {
       ? user.admin && user.admin.includes(organization.id)
       : user.admin && user.admin.includes(activeItem.id);
 
-    if ((user && user.superAdmin) || isAdminOfOrganization) {
+    if (user.superAdmin || isAdminOfOrganization) {
       return true;
     }
 


### PR DESCRIPTION
Remove useless conditional check (`user` would always evaluate to `true`; it is checked earlier in the same function).