### PR TITLE
More objective contributors Firestore rule tweaks

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -66,6 +66,50 @@ service cloud.firestore {
     }
 
     //
+    // Return true if the current user is an admin of the organization that the
+    // document's `item` belongs to *after* performing the action.
+    //
+    function isAdminOfItemAfter(document, type) {
+      let userDoc = getUserDoc();
+      let userIsAdmin = isAdmin();
+      let item = getAfter(/databases/$(database)/documents/$(type)/$(document));
+      let itemDoc = getAfter(item.data.item);
+
+      // Check whether the item of the document the user tries to access has
+      // an organization – this means that it is a product or department.
+      let hasOrgDocumentInItem = 'organization' in itemDoc.data;
+      let isAdminFromOrgOfProdOrDep = userIsAdmin && hasOrgDocumentInItem && getAfter(itemDoc.data.organization).id in userDoc.data.admin;
+
+      // Check whether the user has access to the item, which is an
+      // organization (given that the first check is false).
+      let isAdminOfItem = userIsAdmin && !isAdminFromOrgOfProdOrDep && itemDoc.id in userDoc.data.admin;
+
+      return isSignedIn() && (isAdminFromOrgOfProdOrDep || isAdminOfItem);
+    }
+
+    //
+    // Return true if the current user is an admin of the organization that the
+    // document's `item` belongs to *before* performing the action.
+    //
+    function isAdminOfItemBefore(document, type) {
+      let userDoc = getUserDoc();
+      let userIsAdmin = isAdmin();
+      let item = get(/databases/$(database)/documents/$(type)/$(document));
+      let itemDoc = get(item.data.item);
+
+      // Check whether the item of the document the user tries to access has
+      // an organization – this means that it is a product or department.
+      let hasOrgDocumentInItem = 'organization' in itemDoc.data;
+      let isAdminFromOrgOfProdOrDep = userIsAdmin && hasOrgDocumentInItem && get(itemDoc.data.organization).id in userDoc.data.admin;
+
+      // Check whether the user has access to the item, which is an
+      // organization (given that the first check is false).
+      let isAdminOfItem = userIsAdmin && !isAdminFromOrgOfProdOrDep && itemDoc.id in userDoc.data.admin;
+
+      return isSignedIn() && (isAdminFromOrgOfProdOrDep || isAdminOfItem);
+    }
+
+    //
     // Return true if the current user is an admin of the parent of the
     // document's objective.
     //
@@ -80,6 +124,29 @@ service cloud.firestore {
       // an organization – this means that it is a product or department.
       let hasOrgDocumentInParent = 'organization' in parentDoc.data;
       let isAdminFromOrgOfProdOrDep = userIsAdmin && hasOrgDocumentInParent && getAfter(parentDoc.data.organization).id in userDoc.data.admin;
+
+      // Check whether the user has access to the parent, which is an
+      // organization (given that the first check is false).
+      let isAdminOfParent = userIsAdmin && !isAdminFromOrgOfProdOrDep && parentDoc.id in userDoc.data.admin;
+
+      return isSignedIn() && (isAdminFromOrgOfProdOrDep || isAdminOfParent);
+    }
+
+    //
+    // Return true if the current user is an admin of the parent of the
+    // document's objective *before* performing the action.
+    //
+    function isAdminOfObjectiveParentBefore(document, type) {
+      let userDoc = getUserDoc();
+      let userIsAdmin = isAdmin();
+      let doc = get(/databases/$(database)/documents/$(type)/$(document));
+      let objectiveDoc = get(doc.data.objective);
+      let parentDoc = get(objectiveDoc.data.parent);
+
+      // Check whether the parent of the document the user tries to access has
+      // an organization – this means that it is a product or department.
+      let hasOrgDocumentInParent = 'organization' in parentDoc.data;
+      let isAdminFromOrgOfProdOrDep = userIsAdmin && hasOrgDocumentInParent && get(parentDoc.data.organization).id in userDoc.data.admin;
 
       // Check whether the user has access to the parent, which is an
       // organization (given that the first check is false).
@@ -125,29 +192,51 @@ service cloud.firestore {
     }
 
     //
-    // Return true if the current user is a member of the parent of the
-    // document's objective *before* performing the action.
+    // Return true if the `objective`'s parent is either `item` or its parent
+    // *after* performing the action.
     //
-    function isMemberOfObjectiveParentBefore(document, type) {
-      let userRef = /databases/$(database)/documents/users/$(request.auth.token.email);
-      let doc = get(/databases/$(database)/documents/$(type)/$(document));
-      let objectiveDoc = get(doc.data.objective);
-      let parentDoc = get(objectiveDoc.data.parent);
-      let userIsMemberOfParent = userRef in parentDoc.data.team;
-      return userIsMemberOfParent;
+    function objectiveParentIsItemOrItemParent(document, type) {
+      let doc = getAfter(/databases/$(database)/documents/$(type)/$(document));
+
+      let itemDoc = getAfter(doc.data.item);
+      let objectiveDoc = getAfter(doc.data.objective);
+      let objectiveParentDoc = getAfter(objectiveDoc.data.parent);
+
+      let isProduct = 'department' in itemDoc.data;
+      let isDepartment = 'organization' in itemDoc.data;
+
+      let objectiveParentIsItemParent = (isProduct && getAfter(itemDoc.data.department) == objectiveParentDoc)
+          || (!isProduct && isDepartment && getAfter(itemDoc.data.organization) == objectiveParentDoc);
+
+      return objectiveParentDoc == itemDoc || objectiveParentIsItemParent;
     }
 
     //
-    // Return true if the current user is a member of the parent of the
-    // document's objective *after* performing the action.
+    // Return true if the current user is a member of `item` *after* performing
+    // the action.
     //
-    function isMemberOfObjectiveParentAfter(document, type) {
+    function isMemberOfItemAfter(document, type) {
       let userRef = /databases/$(database)/documents/users/$(request.auth.token.email);
       let doc = getAfter(/databases/$(database)/documents/$(type)/$(document));
-      let objectiveDoc = getAfter(doc.data.objective);
-      let parentDoc = getAfter(objectiveDoc.data.parent);
-      let userIsMemberOfParent = userRef in parentDoc.data.team;
-      return userIsMemberOfParent;
+
+      let itemDoc = getAfter(doc.data.item);
+      let isMemberOfItem = userRef in itemDoc.data.team;
+
+      return isMemberOfItem;
+    }
+
+    //
+    // Return true if the current user is a member of `item` *before*
+    // performing the action.
+    //
+    function isMemberOfItemBefore(document, type) {
+      let userRef = /databases/$(database)/documents/users/$(request.auth.token.email);
+      let doc = get(/databases/$(database)/documents/$(type)/$(document));
+
+      let itemDoc = get(doc.data.item);
+      let isMemberOfItem = userRef in itemDoc.data.team;
+
+      return isMemberOfItem;
     }
 
     function isSelf(document) {
@@ -219,11 +308,10 @@ service cloud.firestore {
       allow delete: if isSuperAdmin();
     }
 
-    // TODO: Should also allow create/delete by organization admins.
     match /objectiveContributors/{document} {
       allow read: if isSignedIn();
-      allow create: if isSuperAdmin() || isMemberOfObjectiveParentAfter(document, 'objectiveContributors') || isAdminOfObjectiveParent(document, 'objectiveContributors');
-      allow delete: if isSuperAdmin() || isMemberOfObjectiveParentBefore(document, 'objectiveContributors') || isAdminOfObjectiveParent(document, 'objectiveContributors');
+      allow create: if isSuperAdmin() || (isMemberOfItemAfter(document, 'objectiveContributors') && objectiveParentIsItemOrItemParent(document, 'objectiveContributors')) || (isAdminOfItemAfter(document, 'objectiveContributors') && isAdminOfObjectiveParent(document, 'objectiveContributors'));
+      allow delete: if isSuperAdmin() || isMemberOfItemBefore(document, 'objectiveContributors') || (isAdminOfItemBefore(document, 'objectiveContributors') && isAdminOfObjectiveParentBefore(document, 'objectiveContributors'));
     }
 
     match /periods/{document} {

--- a/tests/firebase/firestore.test.js
+++ b/tests/firebase/firestore.test.js
@@ -65,7 +65,7 @@ describe('Test Firestore rules', () => {
         name: 'Product X1',
         team: [users.doc('user3@example.com')],
         organization: organizations.doc('organization-x'),
-        department: organizations.doc('department-x'),
+        department: departments.doc('department-x1'),
       });
 
       await objectives.doc('department-x1-objective-1').set({
@@ -75,6 +75,10 @@ describe('Test Firestore rules', () => {
       await objectives.doc('department-y1-objective-1').set({
         name: 'Department Y1 - Objective 1',
         parent: departments.doc('department-y1'),
+      });
+      await objectives.doc('product-x1-objective-1').set({
+        name: 'Product X1 - Objective 1',
+        parent: departments.doc('product-x1'),
       });
 
       await objectiveContributors.doc('objective-contributor-1').set({
@@ -216,6 +220,21 @@ describe('Test Firestore rules', () => {
         objectiveContributors.add({
           objective: objectives.doc('department-x1-objective-1'),
           item: departments.doc('department-x1'),
+        })
+      );
+    });
+  });
+
+  test("users can create objective contributors for objectives on their item's parent item", async () => {
+    await withAuthenticatedUser(testEnv, 'user3@example.com', async (db) => {
+      const objectiveContributors = db.collection('objectiveContributors');
+      const products = db.collection('products');
+      const objectives = db.collection('objectives');
+
+      await expectAddSucceeds(
+        objectiveContributors.add({
+          objective: objectives.doc('department-x1-objective-1'),
+          item: products.doc('product-x1'),
         })
       );
     });

--- a/tests/firebase/firestore.test.js
+++ b/tests/firebase/firestore.test.js
@@ -78,7 +78,7 @@ describe('Test Firestore rules', () => {
       });
       await objectives.doc('product-x1-objective-1').set({
         name: 'Product X1 - Objective 1',
-        parent: departments.doc('product-x1'),
+        parent: products.doc('product-x1'),
       });
 
       await objectiveContributors.doc('objective-contributor-1').set({


### PR DESCRIPTION
Make users able to create objective contributors for objectives on their item's parent item (🤯).