### PR TITLE
Timeline interaction fixes

### DIFF
--- a/src/components/GanttChart.vue
+++ b/src/components/GanttChart.vue
@@ -536,10 +536,14 @@ export default {
       const objectiveElQuery = document.querySelectorAll(`[data-id="${objective.id}"]`);
 
       if (objectiveElQuery.length) {
-        objectiveElQuery[0].scrollIntoView({
-          block: 'center',
-          inline: 'center',
-          behavior: 'smooth',
+        // Delay `scrollIntoView` until the next event cycle. This seems to be
+        // necessary when `behavior` is set to `smooth` in Chrome.
+        setTimeout(() => {
+          objectiveElQuery[0].scrollIntoView({
+            block: 'center',
+            inline: 'center',
+            behavior: 'smooth',
+          });
         });
       }
     },

--- a/src/components/GanttChart.vue
+++ b/src/components/GanttChart.vue
@@ -558,11 +558,17 @@ export default {
 
       this.periodObjectives.map((o) => o.id).forEach(this.addWorkbenchObjective);
 
-      // Set first workbench objective as active
-      await this.$router.replace({
-        name: 'ObjectiveHome',
-        params: { objectiveId: this.periodObjectives[0].id },
-      });
+      // Replace any currently active objective with first from workbench if it
+      // is not part of the selection.
+      if (
+        this.activeObjective &&
+        !this.periodObjectives.find((o) => o.id === this.activeObjective.id)
+      ) {
+        await this.$router.replace({
+          name: 'ObjectiveHome',
+          params: { objectiveId: this.periodObjectives[0].id },
+        });
+      }
 
       this.$nextTick(() => {
         if (this.$refs.period) {


### PR DESCRIPTION
* Fix `scrollIntoView` in Chrome (Mac only?) when selecting objectives in the timeline. Tested in Vivaldi, Chrome and FF (Mac) + Vivaldi (Windows).
* Do not select any objective by default when adding all period objectives to the workbench. This might feel unexpected. (Only _replace_ any already active objective if it is not part of the period selection. This also avoids a redundant navigation error which would occur otherwise.)