### PR TITLE
Fix period progression update error

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -79,7 +79,6 @@ export { KPIDelete as auditKPIDelete } from './audit/index.js';
  */
 export { handleKeyResultProgress } from './progress/index.js';
 export { handleKeyResultProgressOnKeyResultUpdate } from './progress/index.js';
-export { handleKeyResultProgressOnObjectiveUpdate } from './progress/index.js';
 
 // // Express servers run via Cloud Functions
 export { api, internal };

--- a/functions/progress/handleKeyResultProgress.js
+++ b/functions/progress/handleKeyResultProgress.js
@@ -71,7 +71,7 @@ export const updateObjectiveProgression = async (objectiveRef, db) => {
   }
 };
 
-export const updatePeriodProgression = async (periodRef) => {
+const updatePeriodProgression = async (periodRef) => {
   // Finds all progressions for related objectives and updates the period's progression
 
   const db = getFirestore();

--- a/functions/progress/index.js
+++ b/functions/progress/index.js
@@ -1,9 +1,6 @@
 import functions from 'firebase-functions';
 import config from '../config.js';
-import {
-  updateKeyResultProgress,
-  updatePeriodProgression,
-} from './handleKeyResultProgress.js';
+import { updateKeyResultProgress } from './handleKeyResultProgress.js';
 
 export const handleKeyResultProgress = functions
   .runWith(config.runtimeOpts)
@@ -27,29 +24,4 @@ export const handleKeyResultProgressOnKeyResultUpdate = functions
     }
 
     return true;
-  });
-
-export const handleKeyResultProgressOnObjectiveUpdate = functions
-  .runWith(config.runtimeOpts)
-  .region(config.region)
-  .firestore.document(`objectives/{objectiveId}`)
-  .onUpdate(({ before, after }) => {
-    const beforeData = before.data();
-    const afterData = after.data();
-
-    const weightChanged = beforeData.weight !== afterData.weight;
-    const periodChanged = beforeData.period !== afterData.period;
-
-    if (!weightChanged && !periodChanged) {
-      return false;
-    }
-
-    return updatePeriodProgression(afterData.period).then(() => {
-      // Update progression for both periods when an objective's period is altered.
-      if (!periodChanged) {
-        return false;
-      }
-
-      return updatePeriodProgression(beforeData.period);
-    });
   });


### PR DESCRIPTION
Don't attempt to update legacy period progression on objective updates anymore, as objectives are decoupled from their legacy periods automatically when they're updated now, making the update fail.