### PR TITLE
Fix overlapping x-axis dates on small screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ All notable changes to this project will be documented in this file. The format 
   of parent measurements when switching between items.
 - The edit button for key result values is now only visible to users with the
   appropriate permissions.
+- Fixed overlapping dates on the x-axis of some line plots on small screens.
 
 ### Security
 

--- a/src/util/LineChart/index.js
+++ b/src/util/LineChart/index.js
@@ -183,7 +183,7 @@ export default class LineChart {
       .call(
         axisBottom(this.x)
           .tickFormat((d) => formatDate(d, daysBetween))
-          .ticks(Math.min(Math.ceil(daysBetween) || 1, 6))
+          .ticks(Math.min(Math.ceil(daysBetween) || 1, 5))
       )
       .call(styleAxisX);
 


### PR DESCRIPTION
![Screen Shot 2023-11-17 at 11 01 28](https://github.com/oslokommune/okr-tracker/assets/3673262/46bc6d44-0eec-4575-9294-8c9fe9b6c86c)
=>
![Screen Shot 2023-11-17 at 11 01 37](https://github.com/oslokommune/okr-tracker/assets/3673262/36318f50-eb60-4604-a456-4fe70f4f8349)
