### PR TITLE
Don't catch exceptions in backup/restore functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [UNRELEASED]
 
+### Fixed
+
+- Improved error reporting from backup and restore Cloud Functions.
+
 ### Security
 
 - Updated dependencies.

--- a/functions/backupAndRestore.js
+++ b/functions/backupAndRestore.js
@@ -45,10 +45,6 @@ async function restoreBackup() {
     .then(() => {
       console.log(`Backup restored from folder ${backupRoute}`);
       return Promise.resolve();
-    })
-    .catch(async (error) => {
-      console.error('Error message: ', error.message);
-      return Promise.reject(new Error({ message: error.message }));
     });
 }
 
@@ -78,9 +74,5 @@ async function generateBackup() {
     .then(() => {
       console.log(`Backup saved to folder on ${backupRoute}`);
       return Promise.resolve();
-    })
-    .catch(async (error) => {
-      console.error('Error message: ', error.message);
-      return Promise.reject(new Error({ message: error.message }));
     });
 }


### PR DESCRIPTION
Don't catch exceptions that arise in the backup and restore functions, otherwise GCP won't properly interpret them as errors.