### PR TITLE
Fix bug preventing org. admins to add new users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file. The format 
 
 ### Fixed
 
+- Fixed a bug that made organization admins unable to add new users.
 - Improved error reporting from backup and restore Cloud Functions.
 
 ### Security

--- a/src/db/User/User.js
+++ b/src/db/User/User.js
@@ -9,27 +9,20 @@ export const getAllUserIds = () =>
 export const getUserFromId = (id) => collectionReference.doc(id).get();
 
 export const create = async (user) => {
-  try {
-    if (!user.email) {
-      throw new Error('Invalid email');
-    }
-
-    const { exists } = await collectionReference.doc(user.id).get();
-    if (exists) {
-      throw new Error(`User ${user.id} already exists!`);
-    }
-
-    await collectionReference.doc(user.id).set({
-      ...user,
-      superAdmin: false,
-      admin: [],
-      preferences,
-    });
-
-    return true;
-  } catch (error) {
-    throw new Error(`Could not add user ${user.id}`);
+  if (!user.email) {
+    throw new Error('Invalid email');
   }
+
+  const { exists } = await collectionReference.doc(user.id).get();
+  if (exists) {
+    throw new Error(`User ${user.id} already exists!`);
+  }
+
+  await collectionReference.doc(user.id).set({
+    ...user,
+    admin: [],
+    preferences,
+  });
 };
 
 export const remove = async (user) => {
@@ -66,9 +59,7 @@ export const addUsers = async (userList) => {
   if (!userList || !userList.length) {
     throw new Error('Invalid data');
   }
-  const promises = userList
-    .map((email) => ({ id: email, email, superAdmin: false, admin: [] }))
-    .map(create);
+  const promises = userList.map((email) => ({ id: email, email })).map(create);
 
   try {
     return Promise.all(promises);


### PR DESCRIPTION
Organization admins aren't allowed to write the field `superAdmin` for security reasons, so creating new users with `superAdmin: false` would fail even though it's `false`. Just don't write that field at all.