### PR TITLE
Fix plotting of measurements with long comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ All notable changes to this project will be documented in this file. The format 
 
 - Dropped support for Node.js 18 and below.
 
+### Fixed
+
+- Fixed plotting of measurements with very long comments.
+
 ### Security
 
 - Updated dependencies.

--- a/functions/kpi/progress/handleKpiProgress.js
+++ b/functions/kpi/progress/handleKpiProgress.js
@@ -30,7 +30,11 @@ export default async function updateKpiProgress(change, { params }) {
     progressCollection.map((p) => [
       p.timestamp.toDate().toISOString().slice(0, 10),
       parseFloat(p.value.toFixed(4)),
-      p.comment || '',
+      /*
+       * Crop the comment to avoid bloating the cache as Firestore has a limit
+       * of 1 MB per document.
+       */
+      p.comment ? p.comment.substring(0, 500) : '',
     ])
   );
 


### PR DESCRIPTION
Long comments were clogging up the JSON cache (Firestore has a limit of 1 MB per document). Cropping the comments down to 500 characters should push this problem many years into the future.