### PR TITLE
Add modal for restoring items from admin panel

### DIFF
--- a/src/components/modals/ModalWrapper.vue
+++ b/src/components/modals/ModalWrapper.vue
@@ -3,12 +3,27 @@ import { nextTick, onMounted, ref } from 'vue';
 import { useFocusTrap } from '@vueuse/integrations/useFocusTrap';
 import { PktButton } from '@oslokommune/punkt-vue';
 
-defineProps({
+const props = defineProps({
+  title: {
+    type: String,
+    required: false,
+    default: null,
+  },
+  icon: {
+    type: String,
+    required: false,
+    default: null,
+  },
   variant: {
     type: String,
     required: false,
     default: 'normal',
     validator: (value) => ['normal', 'wide'].includes(value),
+  },
+  initialFocus: {
+    type: Boolean,
+    required: false,
+    default: true,
   },
 });
 
@@ -23,7 +38,7 @@ const { activate: activateFocusTrap, deactivate: deactivateFocusTrap } = useFocu
   [modalContent, modal],
   {
     allowOutsideClick: true,
-    initialFocus: true,
+    initialFocus: props.initialFocus,
   }
 );
 
@@ -49,8 +64,9 @@ function close() {
       <div v-if="isOpen" ref="modalOverlay" class="overlay" @keydown.esc="close">
         <div ref="modal" :class="['modal', `modal--${variant}`]">
           <div class="modal__header">
+            <PktIcon v-if="icon" :name="icon" />
             <h1 class="pkt-txt-18-medium">
-              <slot name="header" />
+              <slot name="header">{{ title }}</slot>
             </h1>
             <PktButton
               ref="closeButton"

--- a/src/styles/_modal.scss
+++ b/src/styles/_modal.scss
@@ -50,6 +50,10 @@
     align-items: center;
     margin-bottom: 0.5rem;
 
+    .pkt-icon {
+      width: 1.5rem;
+    }
+
     .pkt-btn {
       align-self: flex-start;
     }

--- a/src/views/Admin/components/AdminItems.vue
+++ b/src/views/Admin/components/AdminItems.vue
@@ -1,9 +1,9 @@
 <script setup>
-import { ref } from 'vue';
+import { useLocalStorage } from '@vueuse/core';
 import { PktCheckbox } from '@oslokommune/punkt-vue';
 import ItemList from './ItemList.vue';
 
-const showArchived = ref(false);
+const showArchived = useLocalStorage('admin-show-archived-items', false);
 </script>
 
 <template>

--- a/src/views/Admin/components/ArchivedItemModal.vue
+++ b/src/views/Admin/components/ArchivedItemModal.vue
@@ -1,0 +1,99 @@
+<script setup>
+import { computed, ref } from 'vue';
+import { useRouter } from 'vue-router';
+import { useI18n } from 'vue-i18n';
+import { useToast } from 'vue-toast-notification';
+import { Organization, Department, Product } from '@/db/models';
+import { PktAlert, PktButton } from '@oslokommune/punkt-vue';
+import { BtnCancel } from '@/components/generic/form';
+import ModalWrapper from '@/components/modals/ModalWrapper.vue';
+
+const router = useRouter();
+const i18n = useI18n();
+const toast = useToast();
+
+const props = defineProps({
+  item: {
+    type: Object,
+    required: true,
+  },
+});
+
+const emit = defineEmits(['close']);
+
+const isLoading = ref(false);
+
+const itemType = computed(() => {
+  if (props.item.organization && props.item.department) {
+    return 'product';
+  }
+  if (props.item.organization) {
+    return 'department';
+  }
+  return 'organization';
+});
+
+const itemModel = computed(() => {
+  if (itemType.value === 'product') {
+    return Product;
+  }
+  if (itemType.value === 'department') {
+    return Department;
+  }
+  return Organization;
+});
+
+const itemIcon = computed(() => {
+  if (itemType.value === 'product') {
+    return 'house-heart';
+  }
+  if (itemType.value === 'department') {
+    return 'district';
+  }
+  return 'organization';
+});
+
+async function restore() {
+  isLoading.value = true;
+  try {
+    await itemModel.value.restore(props.item.id);
+    toast.success(i18n.t('toaster.restored', { name: props.item.name }));
+    router.push({
+      name: 'ItemAbout',
+      params: { slug: props.item.slug },
+      query: { edit: true },
+    });
+  } catch (e) {
+    console.log(e);
+    toast.error(i18n.t('toaster.error.restore', { document: props.item.name }));
+  }
+  isLoading.value = false;
+}
+
+function close() {
+  emit('close');
+}
+</script>
+
+<template>
+  <ModalWrapper :icon="itemIcon" :title="item.name" :initial-focus="false" @close="close">
+    <p class="mb-size-16 pkt-txt-18">{{ item.missionStatement }}</p>
+
+    <PktAlert skin="warning" compact>
+      {{ $t(`archived.body.${itemType}`) }} {{ $t('archived.restoreText') }}
+    </PktAlert>
+
+    <FormSection class="mt-size-16">
+      <template #actions="{ submit, disabled }">
+        <BtnCancel :disabled="disabled || isLoading" @on-click="close" />
+        <PktButton
+          :disabled="disabled || isLoading"
+          icon-name="arrow-circle"
+          variant="icon-left"
+          :text="$t('btn.restore')"
+          @on-click="submit(restore)"
+        />
+      </template>
+    </FormSection>
+  </ModalWrapper>
+</template>

--- a/src/views/Admin/components/ItemList.vue
+++ b/src/views/Admin/components/ItemList.vue
@@ -6,6 +6,7 @@ import { storeToRefs } from 'pinia';
 import { useFuse } from '@vueuse/integrations/useFuse';
 import { db } from '@/config/firebaseConfig';
 import { useAuthStore } from '@/store/auth';
+import ArchivedItemModal from './ArchivedItemModal.vue';
 
 const props = defineProps({
   collection: {
@@ -70,6 +71,7 @@ const filteredItems = computed(() => {
   return items.value.filter((i) => user.value.admin.includes(i.organization.id));
 });
 
+const selectedItem = ref(null);
 const itemQuery = ref('');
 
 const { results: searchResults } = useFuse(itemQuery, filteredItems, {
@@ -114,11 +116,21 @@ const itemRoute = (slug) => ({
 
       <div class="col__body">
         <div v-for="{ item } in searchResults" :key="item.id" class="col__row">
-          <RouterLink class="col__link pkt-txt-16-medium" :to="itemRoute(item.slug)">
+          <RouterLink
+            v-if="!item.archived"
+            class="col__link pkt-txt-16-medium"
+            :to="itemRoute(item.slug)"
+          >
             <PktIcon class="icon" :name="templateConfig.itemIcon" />
             <span class="col__text">{{ item.name }}</span>
-            <PktIcon v-if="item.archived" class="icon" name="archive" />
+            <PktIcon class="icon" name="chevron-right" />
           </RouterLink>
+
+          <div v-else class="col__link pkt-txt-16-medium" @click="selectedItem = item">
+            <PktIcon class="icon" :name="templateConfig.itemIcon" />
+            <span class="col__text">{{ item.name }}</span>
+            <PktIcon class="icon" name="archive" />
+          </div>
         </div>
       </div>
 
@@ -132,6 +144,12 @@ const itemRoute = (slug) => ({
         </RouterLink>
       </div>
     </div>
+
+    <ArchivedItemModal
+      v-if="!!selectedItem"
+      :item="selectedItem"
+      @close="selectedItem = null"
+    />
   </div>
 </template>
 
@@ -173,6 +191,7 @@ const itemRoute = (slug) => ({
   color: var(--color-text);
   text-decoration: none;
   border-bottom: 2px solid var(--color-border);
+  cursor: pointer;
 
   &:hover {
     text-decoration: underline;

--- a/src/views/Admin/components/ItemList.vue
+++ b/src/views/Admin/components/ItemList.vue
@@ -52,7 +52,8 @@ const items = useCollection(
     query(
       collection(db, props.collection),
       where('archived', 'in', [false, props.includeArchived]),
-      orderBy('slug')
+      orderBy('archived', 'asc'),
+      orderBy('slug', 'asc')
     )
   ),
   { ssrKey: `items_${props.collection}` }


### PR DESCRIPTION
Currently, archived items cannot be edited through the admin panel because this involves redirecting the users to a "non-existent" item page. This issue exists in the current version as well.

This PR introduces a modal that prompts the user to restore the selected item before redirecting them to the item edit drawer.