### PR TITLE
Improve handling of timeline ghosts

### DIFF
--- a/src/components/GanttChart.vue
+++ b/src/components/GanttChart.vue
@@ -19,7 +19,8 @@ const { objective: activeObjective } = storeToRefs(useActiveObjectiveStore());
 const ganttObjectives = computed(() => {
   const timelineObjectives = [...objectives.value];
 
-  // Keep currently active objective as a "ghost" until dismissed after it's lifted
+  // Keep currently active objective as a "ghost" until dismissed after
+  // it's lifted or archived
   if (
     activeObjective.value &&
     !timelineObjectives.find((o) => o.id === activeObjective.value.id)

--- a/src/components/ObjectiveLinkCard.vue
+++ b/src/components/ObjectiveLinkCard.vue
@@ -1,4 +1,5 @@
 <script setup>
+import { computed, ref } from 'vue';
 import { storeToRefs } from 'pinia';
 import { useActiveItemStore } from '@/store/activeItem';
 import { PktCheckbox, PktTag } from '@oslokommune/punkt-vue';
@@ -51,8 +52,6 @@ const {
   hasOwnKeyResult,
 } = useObjective(props.objectiveId);
 
-await objectivePromise.value;
-
 async function activate(event, rootHandler) {
   if (props.beforeNavigate) {
     await props.beforeNavigate(event);
@@ -60,11 +59,20 @@ async function activate(event, rootHandler) {
   await rootHandler(event);
 }
 
+const card = ref(null);
+const isGhost = computed(
+  () => objective.value.archived || (isInheritedObjective.value && !hasOwnKeyResult.value)
+);
+
 const commonTagProps = {
   size: 'small',
   textStyle: 'normal-text',
   iconName: 'bullseye',
 };
+
+defineExpose({ ref: card, isGhost });
+
+await objectivePromise.value;
 </script>
 
 <template>
@@ -75,12 +83,13 @@ const commonTagProps = {
     custom
   >
     <a
+      ref="card"
       :class="[
         'objective-link-card',
         {
           'objective-link-card--active': isExactActive || active,
           'objective-link-card--checked': checked,
-          'objective-link-card--dashed': dashed,
+          'objective-link-card--dashed': props.dashed || isGhost,
           'objective-link-card--dimmed': dimmed,
         },
       ]"

--- a/src/components/ObjectiveLinkCard.vue
+++ b/src/components/ObjectiveLinkCard.vue
@@ -59,6 +59,12 @@ async function activate(event, rootHandler) {
   }
   await rootHandler(event);
 }
+
+const commonTagProps = {
+  size: 'small',
+  textStyle: 'normal-text',
+  iconName: 'bullseye',
+};
 </script>
 
 <template>
@@ -92,20 +98,15 @@ async function activate(event, rootHandler) {
             @click.stop="$emit('toggle', $event.target.checked)"
           />
           <div class="objective-link-card__title">
+            <PktTag v-if="isInheritedObjective" v-bind="commonTagProps" skin="blue-light">
+              {{ $t('general.objectiveBy', { owner: objectiveOwner.name }) }}
+            </PktTag>
             <PktTag
-              :skin="
-                isExactActive || active || isInheritedObjective ? 'blue-light' : 'grey'
-              "
-              size="small"
-              text-style="normal-text"
-              icon-name="bullseye"
+              v-else
+              v-bind="commonTagProps"
+              :skin="isExactActive || active ? 'blue-light' : 'grey'"
             >
-              <template v-if="isInheritedObjective">
-                {{ $t('general.objectiveBy', { owner: objectiveOwner.name }) }}
-              </template>
-              <template v-else>
-                {{ $t('general.objective') }}
-              </template>
+              {{ $t('general.objective') }}
             </PktTag>
           </div>
         </div>

--- a/src/components/panes/ObjectivePane.vue
+++ b/src/components/panes/ObjectivePane.vue
@@ -8,7 +8,6 @@ import { useAuthStore } from '@/store/auth';
 import { useActiveOrganizationStore } from '@/store/activeOrganization';
 import { useActiveItemStore } from '@/store/activeItem';
 import { useActiveObjectiveStore } from '@/store/activeObjective';
-import { useOkrsStore } from '@/store/okrs';
 import { PktAlert, PktBreadcrumbs, PktButton } from '@oslokommune/punkt-vue';
 import { compareKeyResults } from '@/util/okr';
 import ObjectiveDetailsCard from '@/components/ObjectiveDetailsCard.vue';
@@ -23,14 +22,16 @@ import FadeTransition from '@/components/generic/transitions/FadeTransition.vue'
 const { user, hasEditRights } = storeToRefs(useAuthStore());
 const { organizationTree } = storeToRefs(useActiveOrganizationStore());
 const { item } = storeToRefs(useActiveItemStore());
-const { objectives } = storeToRefs(useOkrsStore());
 const {
   objective,
+  objectivePromise,
   isLoading: objectiveIsLoading,
   keyResults,
+  keyResultsIsLoading,
 } = storeToRefs(useActiveObjectiveStore());
 
 const pane = ref(null);
+const showLiftWarning = ref(false);
 const renderKeyResults = ref(false);
 const renderWidgets = ref(false);
 
@@ -45,6 +46,7 @@ watch(
     if (to?.id !== from?.id) {
       // Reset and scroll to the top of the pane when the currently active
       // objective changes.
+      showLiftWarning.value = false;
       renderKeyResults.value = false;
       renderWidgets.value = false;
       await nextTick();
@@ -52,6 +54,26 @@ watch(
     }
   },
   { immediate: true }
+);
+
+watch(
+  [objective, keyResults, keyResultsIsLoading],
+  async () => {
+    // Ensure that the objective is completely resovled
+    await objectivePromise.value;
+
+    // The objective is not owned by the currently active item (lifted)
+    const isExternal = objective.value.parent.id !== item.value.id;
+
+    if (!keyResultsIsLoading.value && isExternal) {
+      // Show the lifted object warning if no key results
+      // are owned by the currently active item
+      showLiftWarning.value = !keyResults.value.some(
+        (kr) => kr.parent.id === item.value.id
+      );
+    }
+  },
+  { deep: true }
 );
 
 const orderedKeyResults = computed({
@@ -69,12 +91,6 @@ const orderedKeyResults = computed({
 
     await batch.commit();
   },
-});
-
-const isOwnedByActiveItem = computed(() => {
-  // Return `true` if the objective owner is the currently active
-  const { id: parentId } = objective.value.parent;
-  return parentId === item.value.id;
 });
 
 const isMemberOfChild = computed(() => {
@@ -101,17 +117,6 @@ const isMemberOfChild = computed(() => {
 
   return false;
 });
-
-const isGhost = computed(
-  /**
-   * Returns `true` if the active objective is to be considered a "ghost"
-   * objective.
-   */
-  () =>
-    objectives.value.length &&
-    objective.value &&
-    !objectives.value.find((o) => o.id === objective.value.id)
-);
 
 function keyResultLinkProps(keyResult) {
   return {
@@ -151,7 +156,7 @@ function keyResultLinkProps(keyResult) {
       {{ $t('archived.heading') }}
     </PktAlert>
 
-    <PktAlert v-if="isGhost && !isOwnedByActiveItem" skin="warning" compact>
+    <PktAlert v-if="showLiftWarning" skin="warning" compact>
       <i18n-t keypath="objective.movedWarning" tag="p" scope="global">
         <template #activeItem>
           {{ item.name }}

--- a/src/components/panes/ObjectivePane.vue
+++ b/src/components/panes/ObjectivePane.vue
@@ -26,6 +26,8 @@ const {
   objective,
   objectivePromise,
   isLoading: objectiveIsLoading,
+  isInheritedObjective,
+  hasOwnKeyResult,
   keyResults,
   keyResultsIsLoading,
 } = storeToRefs(useActiveObjectiveStore());
@@ -62,16 +64,10 @@ watch(
     // Ensure that the objective is completely resovled
     await objectivePromise.value;
 
-    // The objective is not owned by the currently active item (lifted)
-    const isExternal = objective.value.parent.id !== item.value.id;
-
-    if (!keyResultsIsLoading.value && isExternal) {
-      // Show the lifted object warning if no key results
-      // are owned by the currently active item
-      showLiftWarning.value = !keyResults.value.some(
-        (kr) => kr.parent.id === item.value.id
-      );
-    }
+    // Show the "lifted" object warning if the object is inherited and no
+    // key results are owned by the currently active item
+    showLiftWarning.value =
+      isInheritedObjective.value && !keyResultsIsLoading.value && !hasOwnKeyResult.value;
   },
   { deep: true }
 );

--- a/src/composables/gantt.js
+++ b/src/composables/gantt.js
@@ -45,6 +45,10 @@ export function useGanttChart(period, loading, objectives) {
        * first.
        */
       .sort((a, b) => startDate(a) - startDate(b))
+      /*
+       * Lastly, sort by created date to maintain a consistent order.
+       */
+      .sort((a, b) => a.created.toDate().getTime() - b.created.toDate().getTime())
   );
 
   /**


### PR DESCRIPTION
There is still a (mostly) visual snag when adding the first objective with an item's parent as the owner. This happens because the objective is initially created with the currently active item as its parent and first updated with the correct parent later, triggering consecutive subscription updates. I don’t remember why it was originally implemented this way. Maybe fix separately if prioritized.